### PR TITLE
fix: build layout

### DIFF
--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -11,9 +11,7 @@ import SwiftUI
 struct ReaderIOSApp: App {
     var body: some Scene {
         WindowGroup {
-            NavigationStack {
-                NavigationPDFSplitView()
-            }
+            NavigationPDFSplitView()
         }
     }
 }


### PR DESCRIPTION
fixes an issue where layout breaks when built.

Turns out SwiftUI does not appreciate nested navigation views.