### PR TITLE
feat(backend): only authenticated users can see unreleased collections

### DIFF
--- a/backend/readers_backend/core/models.py
+++ b/backend/readers_backend/core/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 
-
 class Collection(models.Model):
     major_version = models.IntegerField(blank=False, null=False)
     minor_version = models.IntegerField(blank=False, null=False)


### PR DESCRIPTION
## Description

Only authenticated users (Aaron) can see unreleased collections.

- **Motivation**: _(Why is this change required?)_


Non admin users have no reason to see unreleased collections.
Workbooks are uploaded one at a time so we want to avoid race conditions with collections not being fully uploaded before a client digests it.

## Type of Change

Please delete options that are not relevant.


- [x] **New feature** (non-breaking change which adds functionality)


## Mobile Specific Considerations

- **Platform(s)**:  
  - [ ] iOS  
  - [ ] Android  
  - [x] Both  


## Changes Made

Describe your changes. Include file paths

- Change 1: Filter by is_released=True in get_queryset in CollectionsViewSet if the current request is not authenticated.

## How Has This Been Tested?
Added/modified several tests in test_collections.py


