### PR TITLE
feat(backend): version validation

### DIFF
--- a/backend/readers_backend/core/tests/test_collection.py
+++ b/backend/readers_backend/core/tests/test_collection.py
@@ -109,6 +109,56 @@ class CollectionTestCase(APITestCase):
         self.assertEqual("The fields major_version, minor_version, localization must make a unique set.",
                          response.data['non_field_errors'][0])
 
+    def test_cant_create_with_major_version_lower_than_current_max_major(self):
+        Collection.objects.create(major_version=2, minor_version=0, localization="en-US")
+
+        url = reverse('collection-list')
+
+        bad_body = {
+            "major_version": 1,
+            "minor_version": 0,
+            "localization": "en-US"
+        }
+
+        response = self.client.post(url, bad_body)
+
+        self.assertEqual(
+            response.status_code, 400,
+            msg=f"Expected status code 400, but got {response.status_code}."
+        )
+
+        self.assertIn("major_version", response.data, msg="Expected 'major_version' error in response.")
+        self.assertEqual(
+            response.data["major_version"],
+            ["Must be at least 2 (latest: 2.0)."],
+            msg=f"Unexpected error message: {response.data}"
+        )
+
+    def test_cant_create_with_minor_version_lower_than_current_max_minor(self):
+
+        Collection.objects.create(major_version=1, minor_version=1, localization="en-US")
+
+        url = reverse('collection-list')
+
+        bad_body = {
+            "major_version": 1,
+            "minor_version": 0,
+            "localization": "en-US"
+        }
+
+        response = self.client.post(url, bad_body)
+
+        self.assertEqual(
+            response.status_code, 400,
+            msg=f"Expected status code 400, but got {response.status_code}."
+        )
+
+        self.assertIn("minor_version", response.data, msg="Expected 'minor_version' error in response.")
+        self.assertEqual(
+            response.data["minor_version"],
+            ["Must be greater than 1 (latest: 1.1)."],
+            msg=f"Unexpected error message: {response.data}"
+        )
     def test_create_same_locale_different_version(self):
         url = reverse('collection-list')
 


### PR DESCRIPTION
## Description

This update improves validation for versioning in the Collection model by ensuring that new versions are strictly greater than any previous ones.

- **Motivation**: _(Why is this change required?)_

Prevent versioning mistakes when uploading new collections.

## Type of Change

Please delete options that are not relevant.

- [x ] **New feature** (non-breaking change which adds functionality)

## Mobile Specific Considerations

- **Platform(s)**:  
  - [ ] iOS  
  - [ ] Android  
  - [x ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Updated validate() in the collection serializer to check major and minor versions against the latest workbook.

Describe your changes. Include file paths

- serializers.py -> see changes made.
- test_collections.py -> check small major version, check small minor version given same major.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [x] Django API Tests

