### PR TITLE
feat: moved timer controls to bottom, added custom timer length

### DIFF
--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
@@ -38,8 +38,15 @@ struct TimerControlsView: View {
                     timerManager.startTimer(duration: TimeInterval(Int(customMinutes) * 60))
                 }
 
-                Slider(value: $customMinutes, in: 5 ... 60, step: 5)
+                Slider(value: $customMinutes, in: 0 ... 65, step: 5)
                     .padding(.horizontal)
+                    .onChange(of: customMinutes) {
+                        if customMinutes == 65 {
+                            customMinutes = 5
+                        } else if customMinutes == 0 {
+                            customMinutes = 60
+                        }
+                    }
             }
         } label: {
             Text("Timer")

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
@@ -8,9 +8,22 @@ import SwiftUI
 
 // MARK: - Timer Controls View
 
+enum TimerConstants {
+    // use these constants to set Timer menu options
+    static let options: [Int] = [15, 20, 25]
+    static let defaultCustomOption: Double = 20
+    static let customStep: Double = 5
+    static let customMin: Double = 5
+    static let customMax: Double = 60
+
+    // DO NOT MODIFY: Calculated constants
+    static let actualMin: Double = customMin - customStep
+    static let actualMax: Double = customMax + customStep
+}
+
 struct TimerControlsView: View {
     @ObservedObject var timerManager: TimerManager
-    @State private var customMinutes: Double = 20
+    @State private var customMinutes: Double = TimerConstants.defaultCustomOption
 
     var body: some View {
         // Timer Controls
@@ -21,32 +34,33 @@ struct TimerControlsView: View {
                     .foregroundColor(.gray)
             }
 
-            Button("15 Minutes") {
-                timerManager.startTimer(duration: 15 * 60)
-            }
-            Button("30 Minutes") {
-                timerManager.startTimer(duration: 30 * 60)
-            }
-            Button("45 Minutes") {
-                timerManager.startTimer(duration: 45 * 60)
+            // creates Menu options based off options in TimerConstants
+            ForEach(TimerConstants.options, id: \.self) { minutes in
+                Button("\(minutes) Minutes") {
+                    timerManager.startTimer(duration: TimeInterval(minutes * 60))
+                }
             }
 
             // Custom option with a slider below it
-
             VStack(alignment: .leading) {
-                Button("\(Int(customMinutes)) Minutes [Custom]") {
+                Button("\(Int(customMinutes)) Minutes") {
                     timerManager.startTimer(duration: TimeInterval(Int(customMinutes) * 60))
                 }
 
-                Slider(value: $customMinutes, in: 0 ... 65, step: 5)
-                    .padding(.horizontal)
-                    .onChange(of: customMinutes) {
-                        if customMinutes == 65 {
-                            customMinutes = 5
-                        } else if customMinutes == 0 {
-                            customMinutes = 60
-                        }
+                Slider(
+                    value: $customMinutes,
+                    in: TimerConstants.actualMin ... TimerConstants.actualMax,
+                    step: TimerConstants.customStep
+                )
+                .padding(.horizontal)
+                .onChange(of: customMinutes) {
+                    // logic to loop counter
+                    if customMinutes == TimerConstants.actualMax {
+                        customMinutes = TimerConstants.customMin
+                    } else if customMinutes == TimerConstants.actualMin {
+                        customMinutes = TimerConstants.customMax
                     }
+                }
             }
         } label: {
             Text("Timer")

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
@@ -6,20 +6,24 @@
 //
 import SwiftUI
 
-// MARK: - Timer Controls View
+// MARK: - Timer Constants
 
 enum TimerConstants {
     // use these constants to set Timer menu options
     static let options: [Int] = [15, 20, 25]
+
+    // must be a multiple of customStep
     static let defaultCustomOption: Double = 20
-    static let customStep: Double = 5
-    static let customMin: Double = 5
-    static let customMax: Double = 60
+    static let customStep: Double = 2
+    static let customMin: Double = 2
+    static let customMax: Double = 30
 
     // DO NOT MODIFY: Calculated constants
     static let actualMin: Double = customMin - customStep
     static let actualMax: Double = customMax + customStep
 }
+
+// MARK: - Timer Controls View
 
 struct TimerControlsView: View {
     @ObservedObject var timerManager: TimerManager

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/TimerViews.swift
@@ -10,69 +10,49 @@ import SwiftUI
 
 struct TimerControlsView: View {
     @ObservedObject var timerManager: TimerManager
+    @State private var customMinutes: Double = 20
 
     var body: some View {
         // Timer Controls
-        if timerManager.isTimerRunning {
-            Button {
-                timerManager.pauseTimer()
-            } label: {
-                Image(systemName: "pause.circle")
-                    .foregroundColor(.yellow)
+        Menu {
+            if timerManager.isTimerRunning || timerManager.isPaused {
+                let elapsed = timerManager.selectedDuration - timerManager.remainingDuration
+                Text("\(formatTime(elapsed)) / \(formatTime(timerManager.selectedDuration))")
+                    .foregroundColor(.gray)
             }
 
-            Button {
-                timerManager.restartTimer()
-            } label: {
-                Image(systemName: "arrow.clockwise.circle")
-                    .foregroundColor(.blue)
+            Button("15 Minutes") {
+                timerManager.startTimer(duration: 15 * 60)
+            }
+            Button("30 Minutes") {
+                timerManager.startTimer(duration: 30 * 60)
+            }
+            Button("45 Minutes") {
+                timerManager.startTimer(duration: 45 * 60)
             }
 
-            Button {
-                timerManager.cancelTimer()
-            } label: {
-                Image(systemName: "xmark.circle")
-                    .foregroundColor(.red)
-            }
-        } else if timerManager.isPaused {
-            Button {
-                timerManager.unpauseTimer()
-            } label: {
-                Image(systemName: "play.circle")
-                    .foregroundColor(.green)
-            }
+            // Custom option with a slider below it
 
-            Button {
-                timerManager.restartTimer()
-            } label: {
-                Image(systemName: "arrow.clockwise.circle")
-                    .foregroundColor(.blue)
-            }
-
-            Button {
-                timerManager.cancelTimer()
-            } label: {
-                Image(systemName: "xmark.circle")
-                    .foregroundColor(.red)
-            }
-        } else {
-            Menu {
-                Button("15 Minutes") {
-                    timerManager.startTimer(duration: 15 * 60)
+            VStack(alignment: .leading) {
+                Button("\(Int(customMinutes)) Minutes [Custom]") {
+                    timerManager.startTimer(duration: TimeInterval(Int(customMinutes) * 60))
                 }
-                Button("20 Minutes") {
-                    timerManager.startTimer(duration: 20 * 60)
-                }
-                Button("25 Minutes") {
-                    timerManager.startTimer(duration: 25 * 60)
-                }
-            } label: {
-                Text("Timer")
-                    .padding(5)
-                    .foregroundColor(.blue)
-                    .cornerRadius(8)
+
+                Slider(value: $customMinutes, in: 5 ... 60, step: 5)
+                    .padding(.horizontal)
             }
+        } label: {
+            Text("Timer")
+                .padding(5)
+                .foregroundColor(.blue)
+                .cornerRadius(8)
         }
+    }
+
+    func formatTime(_ seconds: TimeInterval) -> String {
+        let minutes = Int(seconds) / 60
+        let seconds = Int(seconds) % 60
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 }
 
@@ -84,6 +64,50 @@ struct TimerProgressView: View {
 
     var body: some View {
         HStack(spacing: 0) {
+            if timerManager.isTimerRunning {
+                Button {
+                    timerManager.pauseTimer()
+                } label: {
+                    Image(systemName: "pause.circle")
+                        .foregroundColor(.yellow)
+                }
+
+                Button {
+                    timerManager.restartTimer()
+                } label: {
+                    Image(systemName: "arrow.clockwise.circle")
+                        .foregroundColor(.blue)
+                }
+
+                Button {
+                    timerManager.cancelTimer()
+                } label: {
+                    Image(systemName: "xmark.circle")
+                        .foregroundColor(.red)
+                }
+            } else if timerManager.isPaused {
+                Button {
+                    timerManager.unpauseTimer()
+                } label: {
+                    Image(systemName: "play.circle")
+                        .foregroundColor(.green)
+                }
+
+                Button {
+                    timerManager.restartTimer()
+                } label: {
+                    Image(systemName: "arrow.clockwise.circle")
+                        .foregroundColor(.blue)
+                }
+
+                Button {
+                    timerManager.cancelTimer()
+                } label: {
+                    Image(systemName: "xmark.circle")
+                        .foregroundColor(.red)
+                }
+            }
+
             GeometryReader { geometry in
                 ZStack(alignment: .leading) {
                     if timerManager.isTimerRunning || timerManager.isPaused {
@@ -99,7 +123,7 @@ struct TimerProgressView: View {
                             width: geometry.size.width * CGFloat(timerManager.progress),
                             height: 4
                         )
-                        .animation(.linear(duration: 0.1), value: timerManager.progress)
+                        .animation(.linear(duration: 0.01), value: timerManager.progress)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: 4)


### PR DESCRIPTION
## Description

Moved the timer controls to the left of the timer bar while running. 
Added 4th timer option with picker to increment by 5 minutes (range 5-60, looping)
Modified default timer lengths to 15, 30, 45
Shows duration under timer menu when timer is running

- **Motivation**:  Aaron request, top bar crowded, more intuitive, allows for custom options

## Type of Change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [x] iOS  
  - [ ] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

See description above

## How Has This Been Tested?

Manual testing on simulator

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

Can decide to move timer bar to border of top menu bar
