### PR TITLE
Loading screen changes

### DIFF
--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -9,11 +9,17 @@ import Foundation
 import PDFKit
 import SwiftUI
 
+enum FetchConstants {
+    static let maxAttempts = 6
+    static let attemptDelay = 1000
+}
+
 final class InitializationManager: ObservableObject {
     @Published var isInitialized = false
     @Published var loadFailed = false
     @Published var workbooks: [Workbook] = []
     @Published var pdfDocument: PDFDocument?
+    @Published var attempts: Int = 0
 
     init() {
         loadInitialData()
@@ -21,6 +27,7 @@ final class InitializationManager: ObservableObject {
 
     func loadInitialData(delay: Int = 0) {
         let start = DispatchTime.now()
+        self.attempts += 1
 
         NetworkingService.shared.fetchWorkbooks { [weak self] result in
             switch result {

--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -28,7 +28,7 @@ final class InitializationManager: ObservableObject {
 
     func loadInitialData(delay: Int = 0) {
         let start = DispatchTime.now()
-        self.attempts += 1
+        attempts += 1
 
         NetworkingService.shared.fetchWorkbooks { [weak self] result in
             switch result {
@@ -41,6 +41,7 @@ final class InitializationManager: ObservableObject {
                             self?.fetchPDF(for: open.pdfName)
                         }
                     } else {
+                        self?.workbookID = workbooks.first?.id
                         self?.isInitialized = true
                     }
                 }

--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -19,6 +19,7 @@ final class InitializationManager: ObservableObject {
     @Published var loadFailed = false
     @Published var workbooks: [Workbook] = []
     @Published var pdfDocument: PDFDocument?
+    @Published var workbookID: String?
     @Published var attempts: Int = 0
 
     init() {
@@ -34,8 +35,11 @@ final class InitializationManager: ObservableObject {
             case let .success(workbooks):
                 DispatchQueue.main.async {
                     self?.workbooks = workbooks
-                    if let firstWorkbook = workbooks.first {
-                        self?.fetchPDF(for: firstWorkbook.pdfName)
+                    if let savedState = StateRestoreManager.shared.loadState() {
+                        if let open = workbooks.first(where: { $0.id == savedState.workbookID }) {
+                            self?.workbookID = savedState.workbookID
+                            self?.fetchPDF(for: open.pdfName)
+                        }
                     } else {
                         self?.isInitialized = true
                     }

--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -15,13 +15,13 @@ final class InitializationManager: ObservableObject {
     @Published var workbooks: [Workbook] = []
     @Published var pdfDocument: PDFDocument?
 
-    // Optionally load other data (chapters, covers, etc.) as needed
-
     init() {
         loadInitialData()
     }
 
-    func loadInitialData() {
+    func loadInitialData(delay: Int = 0) {
+        let start = DispatchTime.now()
+
         NetworkingService.shared.fetchWorkbooks { [weak self] result in
             switch result {
             case let .success(workbooks):
@@ -35,8 +35,9 @@ final class InitializationManager: ObservableObject {
                 }
             case let .failure(error):
                 print("Error fetching workbooks: \(error)")
-                // Handle error appropriately
-                DispatchQueue.main.async {
+
+                // if delay is set, does not show failure until after delay is elapsed
+                DispatchQueue.main.asyncAfter(deadline: start + .milliseconds(delay)) {
                     self?.loadFailed = true
                 }
             }

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -16,6 +16,7 @@ struct ReaderIOSApp: App {
             if initManager.isInitialized {
                 // Pass any initial data to SplitView as needed.
                 SplitView(initialWorkbooks: initManager.workbooks,
+                          initialWorkbookID: initManager.workbookID,
                           initialPDFDocument: initManager.pdfDocument)
             } else {
                 SplashView(initManager: initManager)

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -18,12 +18,8 @@ struct ReaderIOSApp: App {
                 SplitView(initialWorkbooks: initManager.workbooks,
                           initialPDFDocument: initManager.pdfDocument)
             } else {
-                SplashView(loadFailed: initManager.loadFailed)
+                SplashView(initManager: initManager)
             }
         }
     }
-}
-
-#Preview {
-    SplashView()
 }

--- a/ReaderIOS/ReaderIOS/Views/SplashView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplashView.swift
@@ -35,7 +35,7 @@ struct SplashView: View {
 
                     Button("Reload", action: {
                         initManager.loadFailed = false
-                        initManager.loadInitialData()
+                        initManager.loadInitialData(delay: 1000)
                     })
                     .font(.title3)
                     .buttonStyle(.bordered)

--- a/ReaderIOS/ReaderIOS/Views/SplashView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplashView.swift
@@ -12,49 +12,66 @@ struct SplashView: View {
 
     var body: some View {
         GeometryReader { geometry in
-            VStack(spacing: 20) {
-                // Logo image. Replace "logo" with the name of your image asset.
+            ZStack {
+                Color(UIColor.systemBackground)
+                    .edgesIgnoringSafeArea(.all)
+
+                // Logo positioned above the halfway point.
                 Image("kontinua-logo-full")
                     .resizable()
                     .scaledToFit()
                     .frame(width: geometry.size.width * 0.7)
                     .accessibilityLabel("App Logo")
+                    .position(
+                        x: geometry.size.width / 2,
+                        y: geometry.size.height * 0.40
+                    )
 
-                if initManager.loadFailed {
-                    // Display red alert symbol and red error text.
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 50, height: 50)
-                        .foregroundColor(.red)
+                // Loading or error content positioned below the halfway point.
+                Group {
+                    if initManager.loadFailed {
+                        VStack(spacing: 20) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 50, height: 50)
+                                .foregroundColor(.red)
 
-                    Text("Failed to load workbooks.\n Please check your internet connection and try again.")
-                        .multilineTextAlignment(.center)
-                        .font(.title3)
-                        .foregroundColor(.red)
+                            Text("Failed to load workbooks.\n Please check your internet connection and try again.")
+                                .multilineTextAlignment(.center)
+                                .font(.body)
+                                .foregroundColor(.red)
+                                .frame(width: geometry.size.width * 0.7)
+                                .fixedSize(horizontal: false, vertical: true)
 
-                    if initManager.attempts < FetchConstants.maxAttempts {
-                        Button("Reload", action: {
-                            initManager.loadFailed = false
-                            initManager.loadInitialData(delay: FetchConstants.attemptDelay * initManager.attempts)
-                        })
-                        .font(.title3)
-                        .buttonStyle(.bordered)
+                            if initManager.attempts < FetchConstants.maxAttempts {
+                                Button("Reload") {
+                                    // Hide error and call reload with the desired delay.
+                                    initManager.loadFailed = false
+                                    initManager
+                                        .loadInitialData(delay: FetchConstants.attemptDelay * initManager.attempts)
+                                }
+                                .font(.body)
+                                .buttonStyle(.bordered)
+                            }
+                        }
+                    } else {
+                        VStack(spacing: 20) {
+                            ProgressView()
+                                .controlSize(.large)
+                                .padding(.horizontal)
+
+                            Text("Loading workbooks...")
+                                .font(.body)
+                                .foregroundColor(.secondary)
+                        }
                     }
-
-                } else {
-                    // Show progress bar and loading text.
-                    ProgressView()
-                        .controlSize(.large)
-                        .padding(.horizontal)
-
-                    Text("Loading workbooks...")
-                        .font(.title3)
-                        .foregroundColor(.secondary)
                 }
+                .position(
+                    x: geometry.size.width / 2,
+                    y: geometry.size.height * 0.60
+                )
             }
-            .frame(width: geometry.size.width, height: geometry.size.height)
-            .padding()
         }
     }
 }

--- a/ReaderIOS/ReaderIOS/Views/SplashView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplashView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SplashView: View {
-    var loadFailed: Bool = false
+    @ObservedObject var initManager: InitializationManager
 
     var body: some View {
         GeometryReader { geometry in
@@ -20,7 +20,7 @@ struct SplashView: View {
                     .frame(width: geometry.size.width * 0.7)
                     .accessibilityLabel("App Logo")
 
-                if loadFailed {
+                if initManager.loadFailed {
                     // Display red alert symbol and red error text.
                     Image(systemName: "exclamationmark.triangle.fill")
                         .resizable()
@@ -28,10 +28,17 @@ struct SplashView: View {
                         .frame(width: 50, height: 50)
                         .foregroundColor(.red)
 
-                    Text("Failed to load workbooks.\nPlease try again.")
+                    Text("Failed to load workbooks.\n Please check your internet connection and try again.")
                         .multilineTextAlignment(.center)
                         .font(.title3)
                         .foregroundColor(.red)
+
+                    Button("Reload", action: {
+                        initManager.loadFailed = false
+                        initManager.loadInitialData()
+                    })
+                    .font(.title3)
+                    .buttonStyle(.bordered)
                 } else {
                     // Show progress bar and loading text.
                     ProgressView()

--- a/ReaderIOS/ReaderIOS/Views/SplashView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplashView.swift
@@ -33,12 +33,15 @@ struct SplashView: View {
                         .font(.title3)
                         .foregroundColor(.red)
 
-                    Button("Reload", action: {
-                        initManager.loadFailed = false
-                        initManager.loadInitialData(delay: 1000)
-                    })
-                    .font(.title3)
-                    .buttonStyle(.bordered)
+                    if(initManager.attempts < FetchConstants.maxAttempts){
+                        Button("Reload", action: {
+                            initManager.loadFailed = false
+                            initManager.loadInitialData(delay: FetchConstants.attemptDelay * initManager.attempts)
+                        })
+                        .font(.title3)
+                        .buttonStyle(.bordered)
+                    }
+                    
                 } else {
                     // Show progress bar and loading text.
                     ProgressView()

--- a/ReaderIOS/ReaderIOS/Views/SplashView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplashView.swift
@@ -33,7 +33,7 @@ struct SplashView: View {
                         .font(.title3)
                         .foregroundColor(.red)
 
-                    if(initManager.attempts < FetchConstants.maxAttempts){
+                    if initManager.attempts < FetchConstants.maxAttempts {
                         Button("Reload", action: {
                             initManager.loadFailed = false
                             initManager.loadInitialData(delay: FetchConstants.attemptDelay * initManager.attempts)
@@ -41,7 +41,7 @@ struct SplashView: View {
                         .font(.title3)
                         .buttonStyle(.bordered)
                     }
-                    
+
                 } else {
                     // Show progress bar and loading text.
                     ProgressView()

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SplitView: View {
     var initialWorkbooks: [Workbook] = []
+    var initialWorkbookID: String?
     var initialPDFDocument: PDFDocument?
 
     // Loaded workbooks information state vars
@@ -51,7 +52,7 @@ struct SplitView: View {
                     .onAppear {
                         if !initialWorkbooks.isEmpty {
                             workbooks = initialWorkbooks
-                            selectedWorkbookID = initialWorkbooks.first?.id
+                            selectedWorkbookID = initialWorkbookID
                         }
                     }
             }
@@ -152,10 +153,12 @@ struct SplitView: View {
                         currentPage = savedState.pageNumber
                     } else {
                         // Fallback: default to the first workbook if the saved one isn't found.
+                        print("defaulting to first ")
                         selectedWorkbookID = workbookResponse.first?.id
                     }
                 } else {
                     // No saved state, so select the first workbook by default.
+                    print("no saved state")
                     selectedWorkbookID = workbookResponse.first?.id
                 }
             case let .failure(error):


### PR DESCRIPTION
## Description

Various changes to the behavior of the loading screen and the app initialization

- **Motivation**: Aaron requested a change to the error message if workbooks are not loaded, also needed to prepare for backend integration

## Type of Change

Please delete options that are not relevant.

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [x] iOS  
  - [ ] Android  
  - [ ] Both  

## Changes Made

`ReaderIOS/ReaderIOS/Views/SplashView.swift`
- Change 1: Changed error message on load to say "check internet connection
- Change 2: Added reload button with dynamic reset time based on # of attempts

`ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift`
- Change 3: Added enum to specify constants for loading attempt limits
- Change 4: Modified default opening logic to check for 

`ReaderIOS/ReaderIOS/ReaderIOSApp.swift`
- Change 5: Pass in initManager to SplashView instead of just loadingFailed bool

`ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift`
- Change 6: Added initial workbook var to be passed in from InitializationManager

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

