### PR TITLE
timer colors and function matches ios

### DIFF
--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/viewmodels/TimerViewModel.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/viewmodels/TimerViewModel.kt
@@ -12,26 +12,41 @@ import kotlinx.coroutines.launch
 
 class TimerViewModel : ViewModel() {
     var isTimerRunning by mutableStateOf(false)
-    var timerDuration by mutableLongStateOf(15 * 60 * 1000L)
+    var timerDuration by mutableLongStateOf(15 * 6 * 1000L)
         private set
 
     var timeLeftMillis by mutableLongStateOf(0)
+        private set
+
+    var isTimerFinished by mutableStateOf(false)
         private set
 
     private var timerJob: Job? = null
 
     fun startTimer(initialTimeMillis: Long = timerDuration) {
         timerJob?.cancel()
+        isTimerFinished = false
         timeLeftMillis = initialTimeMillis
         isTimerRunning = true
 
-        timerJob = CoroutineScope(Dispatchers.Main).launch {
-            while (timeLeftMillis > 0) {
-                delay(100)
-                timeLeftMillis -= 100
-            }
+        if (initialTimeMillis <= 0) {
             isTimerRunning = false
             timeLeftMillis = 0
+            return
+        }
+
+        timerJob = CoroutineScope(Dispatchers.Main).launch {
+            while (timeLeftMillis > 0 && isTimerRunning) {
+                delay(100)
+                if (isTimerRunning) {
+                    timeLeftMillis = (timeLeftMillis - 100).coerceAtLeast(0L)
+                }
+            }
+            if (timeLeftMillis <= 0) {
+                isTimerRunning = false
+                isTimerFinished = true
+                timeLeftMillis = 0
+            }
         }
     }
 
@@ -48,6 +63,7 @@ class TimerViewModel : ViewModel() {
         timerJob?.cancel()
         timeLeftMillis = 0
         isTimerRunning = false
+        isTimerFinished = false
     }
 
     fun setDurationAndReset(durationMillis: Long) {

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/bottombar/BottomBarComponent.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/bottombar/BottomBarComponent.kt
@@ -32,13 +32,15 @@ fun BottomBarComponent(
 ) {
     val isTimerRunning = timerViewModel.isTimerRunning
     val timeLeftMillis = timerViewModel.timeLeftMillis
+    val isTimerFinished = timerViewModel.isTimerFinished
+    val showTimerControls = timeLeftMillis > 0 || isTimerFinished
 
     BottomAppBar(modifier = modifier) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (timeLeftMillis > 0) {
+            if (showTimerControls) {
                 TimerControls(
                     isRunning = isTimerRunning,
                     onPauseResume = {

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/bottombar/timer/TimerProgressIndicator.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/bottombar/timer/TimerProgressIndicator.kt
@@ -1,43 +1,54 @@
 package com.kontinua.readersandroidjetpack.views.bottombar.timer
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import com.kontinua.readersandroidjetpack.viewmodels.TimerViewModel
-import kotlinx.coroutines.delay
 
-/**
- * A standalone timer progress indicator that can be used independently
- * from the timer controls.
- */
 @Composable
 fun TimerProgressIndicator(timerViewModel: TimerViewModel) {
+    // Get states from ViewModel
     val isTimerRunning = timerViewModel.isTimerRunning
     val timerDuration = timerViewModel.timerDuration
     val timeLeftMillis = timerViewModel.timeLeftMillis
+    val isTimerFinished = timerViewModel.isTimerFinished
+    val isVisible = timeLeftMillis > 0 || isTimerFinished
 
+    val targetProgress = when {
+        isTimerFinished -> 1f
+        timerDuration > 0 -> 1f - (timeLeftMillis.toFloat() / timerDuration)
+        else -> 0f // Default case (timerDuration is 0 or less)
+    }
     val progress by animateFloatAsState(
-        targetValue = if (timerDuration > 0) 1f - (timeLeftMillis.toFloat() / timerDuration) else 0f, // Invert progress
+        targetValue = targetProgress,
         label = "timerProgress"
     )
 
-    LaunchedEffect(timeLeftMillis) {
-        if (timeLeftMillis > 0) {
-            delay(100)
-        }
+    val targetColor = when {
+        isTimerFinished -> Color(0xFF19BA00)
+        isTimerRunning -> Color.Red
+        timeLeftMillis > 0 -> Color(0xFFFFDB33)
+        else -> Color.Transparent
     }
 
-    if (timeLeftMillis > 0) { // Only show the progress bar if time is left
+    val animatedColor by animateColorAsState(
+        targetValue = targetColor,
+        label = "timerColor"
+    )
+
+    if (isVisible) {
         LinearProgressIndicator(
             progress = { progress },
             modifier = Modifier.fillMaxWidth(),
-            color = if (isTimerRunning) Color.Green else Color.Yellow,
+            color = animatedColor,
             trackColor = Color.LightGray,
+            strokeCap = StrokeCap.Round
         )
     }
 }

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/topbar/Toolbar.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/topbar/Toolbar.kt
@@ -49,7 +49,7 @@ fun Toolbar(
                 onDismissRequest = { showTimerMenu = false }
             ) {
                 DropdownMenuItem(text = { Text("15 Minutes") }, onClick = {
-                    timerViewModel.setDurationAndReset(15 * 60 * 1000L)
+                    timerViewModel.setDurationAndReset(15 * 1000L)
                     showTimerMenu = false
                 })
                 DropdownMenuItem(text = { Text("20 Minutes") }, onClick = {


### PR DESCRIPTION
## Description

timer was not perfectly put into composable yet, colors and functions will now match ios better! 15 minute dropdown is set to 15 seconds so we can test what happens as timer completes. 

- **Motivation**: _(Why is this change required?)_

## Type of Change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [ ] iOS  
  - [x] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

- Change 1: updated the timer colors to match ios
- Change 2: when timer completes, bar appears green but does not disappear
- Change 3: when timer completes, controls stay visible as long as the bar is visible

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.
