### PR TITLE
BUG #1 PAGE SELECTOR ERRATIC BEHAVIOR

### DIFF
--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/util/constants.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/util/constants.kt
@@ -1,5 +1,5 @@
 package com.kontinua.readersandroidjetpack.util
 
 object Constants {
-    const val API_URL = "https://d5hsjjmy8w.us-west-2.awsapprunner.com/api"
+    const val API_URL = "http://10.144.202.134:8000/api"
 }


### PR DESCRIPTION
## Description

Please include a summary of the changes. Also include relevant motivation and context. List any dependencies that are required for this change.

- **Motivation**: _(Why is this change required?)_
- need to fix the page selector: when inputting too high a number it would go to your current page - one

## Type of Change

Please delete options that are not relevant.

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [ ] iOS  
  - [x] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

-Change 1: _(updated the page selector so now inputting too large a number auto navigates to the last page per aarons request)_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

Add any other context about the pull request here.
