### PR TITLE
iOS loading bug fix/streamline of initialization, review prep

### DIFF
--- a/ReaderIOS/ReaderIOS.xcodeproj/xcuserdata/ethanhandelman.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ReaderIOS/ReaderIOS.xcodeproj/xcuserdata/ethanhandelman.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "F9D61632-01C0-496F-83EA-7B6384240EA9"
    type = "1"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "47A4BADF-F406-43AB-B27D-DBEBD6C4727E"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ReaderIOS/ReaderIOSApp.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "13"
-            endingLineNumber = "13"
-            landmarkName = "ReaderIOSApp"
-            landmarkType = "14">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/ReaderIOS/ReaderIOS.xcodeproj/xcuserdata/ethanhandelman.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ReaderIOS/ReaderIOS.xcodeproj/xcuserdata/ethanhandelman.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "F9D61632-01C0-496F-83EA-7B6384240EA9"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "47A4BADF-F406-43AB-B27D-DBEBD6C4727E"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "ReaderIOS/ReaderIOSApp.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "13"
+            endingLineNumber = "13"
+            landmarkName = "ReaderIOSApp"
+            landmarkType = "14">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -17,7 +17,7 @@ enum FetchConstants {
 final class InitializationManager: ObservableObject {
     @Published var isInitialized = false
     @Published var loadFailed = false
-    @Published var workbooks: [WorkbookPreview] = []
+    @Published var workbooks: [WorkbookPreview]?
     @Published var pdfDocument: PDFDocument?
     @Published var workbookID: Int?
     @Published var latestCollection: Collection?

--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -94,7 +94,7 @@ final class InitializationManager: ObservableObject {
                 case let .failure(error):
                     print("Error fetching initial workbook information: \(error)")
                 }
-                
+
                 self?.isInitialized = true
             }
         }

--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -91,7 +91,7 @@ final class InitializationManager: ObservableObject {
                 switch result {
                 case let .success(workbook):
                     self?.workbook = workbook
-                    self?.fetchPDF(for: workbook)
+                    //self?.fetchPDF(for: workbook)
                 case let .failure(error):
                     print("Error fetching PDF: \(error)")
                 }

--- a/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift
@@ -75,7 +75,7 @@ final class InitializationManager: ObservableObject {
                     }
                 }
             case let .failure(error):
-                print("Error fetching workbooks: \(error)")
+                print("Error fetching initial workbooks: \(error)")
 
                 // if delay is set, does not show failure until after delay is elapsed
                 DispatchQueue.main.asyncAfter(deadline: start + .milliseconds(self?.delay ?? 0)) {
@@ -91,23 +91,11 @@ final class InitializationManager: ObservableObject {
                 switch result {
                 case let .success(workbook):
                     self?.workbook = workbook
-                    //self?.fetchPDF(for: workbook)
                 case let .failure(error):
-                    print("Error fetching PDF: \(error)")
+                    print("Error fetching initial workbook information: \(error)")
                 }
-                // Mark initialization complete regardless; you could also have error states.
+                
                 self?.isInitialized = true
-            }
-        }
-    }
-
-    private func fetchPDF(for workbook: Workbook) {
-        NetworkingService.shared.fetchPDF(workbook: workbook) { [weak self] result in
-            switch result {
-            case let .success(pdf):
-                self?.pdfDocument = pdf
-            case let .failure(error):
-                print("Error fetching PDF: \(error)")
             }
         }
     }

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct ReaderIOSApp: App {
     @StateObject private var initManager = InitializationManager()
-    
+
     var body: some Scene {
         WindowGroup {
             if initManager.isInitialized {

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -15,11 +15,11 @@ struct ReaderIOSApp: App {
         WindowGroup {
             if initManager.isInitialized {
                 SplitView(
-                          workbooks: $initManager.workbooks,
-                          currentCollection: $initManager.latestCollection,
+                          workbooks: initManager.workbooks,
+                          currentCollection: initManager.latestCollection,
                           selectedWorkbookID: 0,
                           currentWorkbook: initManager.workbook,
-                          pdfDocument: $initManager.pdfDocument
+                          pdfDocument: initManager.pdfDocument
                         
                 )
             } else {

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -10,17 +10,15 @@ import SwiftUI
 @main
 struct ReaderIOSApp: App {
     @StateObject private var initManager = InitializationManager()
-
+    
     var body: some Scene {
         WindowGroup {
             if initManager.isInitialized {
                 SplitView(
-                          workbooks: initManager.workbooks,
-                          currentCollection: initManager.latestCollection,
-                          selectedWorkbookID: initManager.workbookID,
-                          currentWorkbook: initManager.workbook
-                          //pdfDocument: initManager.pdfDocument
-                        
+                    workbooks: initManager.workbooks,
+                    currentCollection: initManager.latestCollection,
+                    selectedWorkbookID: initManager.workbookID,
+                    currentWorkbook: initManager.workbook
                 )
             } else {
                 SplashView(initManager: initManager)

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -14,11 +14,14 @@ struct ReaderIOSApp: App {
     var body: some Scene {
         WindowGroup {
             if initManager.isInitialized {
-                SplitView(initialWorkbookID: initManager.workbookID,
+                SplitView(
                           workbooks: $initManager.workbooks,
                           currentCollection: $initManager.latestCollection,
+                          selectedWorkbookID: 0,
+                          currentWorkbook: initManager.workbook,
                           pdfDocument: $initManager.pdfDocument
-                          )
+                        
+                )
             } else {
                 SplashView(initManager: initManager)
             }

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -14,10 +14,11 @@ struct ReaderIOSApp: App {
     var body: some Scene {
         WindowGroup {
             if initManager.isInitialized {
-                SplitView(initialWorkbooks: initManager.workbooks,
-                          initialWorkbookID: initManager.workbookID,
-                          initialPDFDocument: initManager.pdfDocument,
-                          initialCollection: initManager.latestCollection)
+                SplitView(initialWorkbookID: initManager.workbookID,
+                          workbooks: $initManager.workbooks,
+                          currentCollection: $initManager.latestCollection,
+                          pdfDocument: $initManager.pdfDocument
+                          )
             } else {
                 SplashView(initManager: initManager)
             }

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -18,8 +18,8 @@ struct ReaderIOSApp: App {
                           workbooks: initManager.workbooks,
                           currentCollection: initManager.latestCollection,
                           selectedWorkbookID: initManager.workbookID,
-                          currentWorkbook: initManager.workbook,
-                          pdfDocument: initManager.pdfDocument
+                          currentWorkbook: initManager.workbook
+                          //pdfDocument: initManager.pdfDocument
                         
                 )
             } else {

--- a/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
+++ b/ReaderIOS/ReaderIOS/ReaderIOSApp.swift
@@ -17,7 +17,7 @@ struct ReaderIOSApp: App {
                 SplitView(
                           workbooks: initManager.workbooks,
                           currentCollection: initManager.latestCollection,
-                          selectedWorkbookID: 0,
+                          selectedWorkbookID: initManager.workbookID,
                           currentWorkbook: initManager.workbook,
                           pdfDocument: initManager.pdfDocument
                         

--- a/ReaderIOS/ReaderIOS/Services/NetworkingService.swift
+++ b/ReaderIOS/ReaderIOS/Services/NetworkingService.swift
@@ -101,7 +101,9 @@ final class NetworkingService: ObservableObject {
             completion(.failure(NetworkError.invalidURL))
             return
         }
+        
         startLoading()
+        
         var request = URLRequest(url: url)
         request.cachePolicy = .reloadIgnoringLocalCacheData
 

--- a/ReaderIOS/ReaderIOS/Services/NetworkingService.swift
+++ b/ReaderIOS/ReaderIOS/Services/NetworkingService.swift
@@ -101,9 +101,9 @@ final class NetworkingService: ObservableObject {
             completion(.failure(NetworkError.invalidURL))
             return
         }
-        
+
         startLoading()
-        
+
         var request = URLRequest(url: url)
         request.cachePolicy = .reloadIgnoringLocalCacheData
 

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
@@ -165,7 +165,7 @@ struct PDFView: View {
                                 HStack(spacing: 0) {
                                     TimerProgressView(timerManager: timerManager)
                                         .frame(maxWidth: .infinity)
-                                    
+
                                     FeedbackView.button(
                                         feedbackManager: feedbackManager,
                                         workbook: currentWorkbook,

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
@@ -3,19 +3,19 @@ import SwiftUI
 
 struct PDFView: View {
     // MARK: - Bindings
-
+    
     @Binding var currentWorkbook: Workbook?
     @Binding var currentPage: Int
     @Binding var covers: [Cover]?
     @Binding var pdfDocument: PDFDocument?
     @Binding var collection: Collection?
-
+    
     // MARK: - Observed Objects
-
+    
     @ObservedObject var bookmarkManager: BookmarkManager
-
+    
     // MARK: - State Variables
-
+    
     // misc variables
     @State private var showDigitalResources = false
     @State private var showingFeedback = false
@@ -33,165 +33,165 @@ struct PDFView: View {
     @State private var textOpened = false
     @State private var isHidden = false
     @State private var showClearAlert = false
-
+    
     // MARK: - StateObjects and Observed
-
+    
     @StateObject private var feedbackManager = FeedbackManager()
     @StateObject private var timerManager = TimerManager()
     @ObservedObject private var zoomManager = ZoomManager()
     @ObservedObject private var textManager = TextManager()
     @ObservedObject private var annotationStorageManager = AnnotationStorageManager()
-
+    
     // MARK: - Body
-
+    
     var body: some View {
         GeometryReader { geometry in
             NavigationStack {
                 ZStack {
-                    VStack {
-                        if let pdfDoc = pdfDocument {
-                            ZStack {
-                                // PDF Document View
-                                DocumentView(
-                                    pdfDocument: pdfDoc,
-                                    currentPageIndex: $currentPage
-                                )
-                                .edgesIgnoringSafeArea(.all)
-                                .scaleEffect(zoomManager.newZoomLevel(),
-                                             anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
-                                .onChange(of: currentPage) { _, newValue in
-                                    loadPaths(for: newValue)
+                    
+                    if let pdfDoc = pdfDocument {
+                        ZStack {
+                            // PDF Document View
+                            DocumentView(
+                                pdfDocument: pdfDoc,
+                                currentPageIndex: $currentPage
+                            )
+                            .edgesIgnoringSafeArea(.all)
+                            .scaleEffect(zoomManager.newZoomLevel(),
+                                         anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
+                            .onChange(of: currentPage) { _, newValue in
+                                loadPaths(for: newValue)
+                            }
+                            
+                            // Annotations
+                            AnnotationsView(
+                                pagePaths: $pagePaths,
+                                highlightPaths: $highlightPaths,
+                                selectedScribbleTool: $selectedScribbleTool,
+                                textOpened: $textOpened,
+                                key: uniqueKey(for: currentPage),
+                                nextPage: { goToNextPage() },
+                                previousPage: { goToPreviousPage() },
+                                selectedColor: selectedPenColor,
+                                selectedHighlighterColor: selectedHighlighterColor,
+                                zoomedIn: zoomManager.getZoomedIn(),
+                                zoomManager: zoomManager,
+                                annotationManager: annotationStorageManager,
+                                textManager: textManager,
+                                textBoxes: $textBoxes
+                            )
+                            .scaleEffect(zoomManager.newZoomLevel(),
+                                         anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
+                            
+                            // Text Overlay
+                            TextView(
+                                textManager: textManager,
+                                textBoxes: $textBoxes,
+                                key: uniqueKey(for: currentPage),
+                                deleteTextBox: $deleteTextBox,
+                                currentTextBoxIndex: $currentTextBox,
+                                width: geometry.size.width,
+                                height: geometry.size.height,
+                                textOpened: $textOpened,
+                                isHidden: $isHidden
+                            )
+                            .scaleEffect(zoomManager.newZoomLevel(),
+                                         anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
+                            .alert("Are you sure you want to delete the text box?",
+                                   isPresented: $deleteTextBox)
+                            {
+                                Button("Delete", role: .destructive) {
+                                    textOpened = false
+                                    textManager.deleteText(
+                                        textBoxes: $textBoxes,
+                                        key: uniqueKey(for: currentPage),
+                                        index: currentTextBox
+                                    )
+                                    textManager.saveTextBoxes(textBoxes: textBoxes)
+                                    currentTextBox = -1
                                 }
-
-                                // Annotations
-                                AnnotationsView(
-                                    pagePaths: $pagePaths,
-                                    highlightPaths: $highlightPaths,
+                                Button("Cancel", role: .cancel) {
+                                    currentTextBox = -1
+                                }
+                            }
+                        }
+                        .toolbar {
+                            ToolbarItemGroup(placement: .navigationBarLeading) {
+                                PageControlView(currentPage: $currentPage, totalPages: pdfDoc.pageCount)
+                                    .padding(.leading, 10)
+                            }
+                            
+                            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                                TimerControlsView(timerManager: timerManager)
+                                MarkupMenu(
                                     selectedScribbleTool: $selectedScribbleTool,
-                                    textOpened: $textOpened,
-                                    key: uniqueKey(for: currentPage),
-                                    nextPage: { goToNextPage() },
-                                    previousPage: { goToPreviousPage() },
-                                    selectedColor: selectedPenColor,
-                                    selectedHighlighterColor: selectedHighlighterColor,
-                                    zoomedIn: zoomManager.getZoomedIn(),
-                                    zoomManager: zoomManager,
+                                    exitNotSelected: $exitNotSelected,
+                                    showClearAlert: $showClearAlert,
+                                    selectedPenColor: $selectedPenColor,
+                                    selectedHighlighterColor: $selectedHighlighterColor,
+                                    isPenSubmenuVisible: $isPenSubmenuVisible,
+                                    textBoxes: $textBoxes,
                                     annotationManager: annotationStorageManager,
                                     textManager: textManager,
-                                    textBoxes: $textBoxes
+                                    pagePaths: pagePaths,
+                                    highlightPaths: highlightPaths
                                 )
-                                .scaleEffect(zoomManager.newZoomLevel(),
-                                             anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
-
-                                // Text Overlay
-                                TextView(
-                                    textManager: textManager,
-                                    textBoxes: $textBoxes,
-                                    key: uniqueKey(for: currentPage),
-                                    deleteTextBox: $deleteTextBox,
-                                    currentTextBoxIndex: $currentTextBox,
-                                    width: geometry.size.width,
-                                    height: geometry.size.height,
-                                    textOpened: $textOpened,
-                                    isHidden: $isHidden
-                                )
-                                .scaleEffect(zoomManager.newZoomLevel(),
-                                             anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
-                                .alert("Are you sure you want to delete the text box?",
-                                       isPresented: $deleteTextBox)
-                                {
-                                    Button("Delete", role: .destructive) {
-                                        textOpened = false
-                                        textManager.deleteText(
-                                            textBoxes: $textBoxes,
-                                            key: uniqueKey(for: currentPage),
-                                            index: currentTextBox
-                                        )
-                                        textManager.saveTextBoxes(textBoxes: textBoxes)
-                                        currentTextBox = -1
-                                    }
-                                    Button("Cancel", role: .cancel) {
-                                        currentTextBox = -1
+                                
+                                Button(action: { showDigitalResources = true }, label: {
+                                    Text("Digital Resources")
+                                        .padding(5)
+                                        .foregroundColor((covers?.isEmpty ?? true) ? .gray : .purple)
+                                        .cornerRadius(8)
+                                })
+                                .disabled(covers?.isEmpty ?? true)
+                                .fullScreenCover(isPresented: $showDigitalResources, content: {
+                                    DigitalResourcesView(covers: covers)
+                                })
+                                
+                                Button {
+                                    bookmarkManager.toggleBookmark(for: currentWorkbook, currentPage: currentPage)
+                                } label: {
+                                    Image(systemName: bookmarkManager.isBookmarked(
+                                        workbook: currentWorkbook,
+                                        currentPage: currentPage
+                                    ) ? "bookmark.fill" : "bookmark")
+                                    .foregroundColor(.yellow)
+                                }
+                                
+                                if zoomManager.getZoomedIn() {
+                                    Button("Reset Zoom") {
+                                        zoomManager.resetZoom()
                                     }
                                 }
                             }
-                            .toolbar {
-                                ToolbarItemGroup(placement: .navigationBarLeading) {
-                                    PageControlView(currentPage: $currentPage, totalPages: pdfDoc.pageCount)
-                                        .padding(.leading, 10)
-                                }
-
-                                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                                    TimerControlsView(timerManager: timerManager)
-                                    MarkupMenu(
-                                        selectedScribbleTool: $selectedScribbleTool,
-                                        exitNotSelected: $exitNotSelected,
-                                        showClearAlert: $showClearAlert,
-                                        selectedPenColor: $selectedPenColor,
-                                        selectedHighlighterColor: $selectedHighlighterColor,
-                                        isPenSubmenuVisible: $isPenSubmenuVisible,
-                                        textBoxes: $textBoxes,
-                                        annotationManager: annotationStorageManager,
-                                        textManager: textManager,
-                                        pagePaths: pagePaths,
-                                        highlightPaths: highlightPaths
+                            ToolbarItemGroup(placement: .bottomBar) {
+                                // Create a horizontal stack for the entire bottom toolbar
+                                HStack(spacing: 0) {
+                                    // Timer controls and progress bar should fill available space
+                                    TimerProgressView(timerManager: timerManager)
+                                        .frame(maxWidth: .infinity)
+                                    
+                                    // Feedback button with minimal spacing
+                                    FeedbackView.button(
+                                        feedbackManager: feedbackManager,
+                                        workbook: currentWorkbook,
+                                        currentPage: currentPage,
+                                        collection: collection
                                     )
-
-                                    Button(action: { showDigitalResources = true }, label: {
-                                        Text("Digital Resources")
-                                            .padding(5)
-                                            .foregroundColor((covers?.isEmpty ?? true) ? .gray : .purple)
-                                            .cornerRadius(8)
-                                    })
-                                    .disabled(covers?.isEmpty ?? true)
-                                    .fullScreenCover(isPresented: $showDigitalResources, content: {
-                                        DigitalResourcesView(covers: covers)
-                                    })
-
-                                    Button {
-                                        bookmarkManager.toggleBookmark(for: currentWorkbook, currentPage: currentPage)
-                                    } label: {
-                                        Image(systemName: bookmarkManager.isBookmarked(
-                                            workbook: currentWorkbook,
-                                            currentPage: currentPage
-                                        ) ? "bookmark.fill" : "bookmark")
-                                            .foregroundColor(.yellow)
-                                    }
-
-                                    if zoomManager.getZoomedIn() {
-                                        Button("Reset Zoom") {
-                                            zoomManager.resetZoom()
-                                        }
-                                    }
-                                }
-                                ToolbarItemGroup(placement: .bottomBar) {
-                                    // Create a horizontal stack for the entire bottom toolbar
-                                    HStack(spacing: 0) {
-                                        // Timer controls and progress bar should fill available space
-                                        TimerProgressView(timerManager: timerManager)
-                                            .frame(maxWidth: .infinity)
-
-                                        // Feedback button with minimal spacing
-                                        FeedbackView.button(
-                                            feedbackManager: feedbackManager,
-                                            workbook: currentWorkbook,
-                                            currentPage: currentPage,
-                                            collection: collection
-                                        )
-                                        .padding(.leading, 4) // Minimal padding between progress bar and button
-                                    }
+                                    .padding(.leading, 4) // Minimal padding between progress bar and button
                                 }
                             }
-                        } else {
-                            ProgressView("Getting Workbook")
-                                .onAppear {
-                                    loadPDFDocument()
-                                    annotationStorageManager.loadAnnotations(pagePaths: &pagePaths,
-                                                                             highlightPaths: &highlightPaths)
-                                    textManager.loadTextBoxes(textBoxes: &textBoxes)
-                                }
                         }
+                    } else {
+                        ProgressView("Getting workbook...")
+                            .onAppear {
+                                loadPDFDocument()
+                                annotationStorageManager.loadAnnotations(pagePaths: &pagePaths,
+                                                                         highlightPaths: &highlightPaths)
+                                textManager.loadTextBoxes(textBoxes: &textBoxes)
+                            }
                     }
+                    
                 }
                 .onDisappear {
                     textManager.saveTextBoxes(textBoxes: textBoxes)
@@ -213,12 +213,12 @@ struct PDFView: View {
             }
         }
     }
-
+    
     // MARK: - Helper Methods
-
+    
     private func loadPDFDocument() {
         guard let currentWorkbook = currentWorkbook else { return }
-
+        
         NetworkingService.shared.fetchPDF(workbook: currentWorkbook) { result in
             switch result {
             case let .success(document):
@@ -228,31 +228,31 @@ struct PDFView: View {
             }
         }
     }
-
+    
     private func loadPaths(for pageIndex: Int) {
         let key = uniqueKey(for: pageIndex)
         if pagePaths[key] == nil { pagePaths[key] = [] }
         if highlightPaths[key] == nil { highlightPaths[key] = [] }
     }
-
+    
     private func uniqueKey(for pageIndex: Int) -> String {
         guard let workbook = currentWorkbook else { return "\(pageIndex)" }
         return "\(workbook.id)-\(pageIndex)"
     }
-
+    
     private func clearMarkup() {
         let key = uniqueKey(for: currentPage)
         highlightPaths.removeValue(forKey: key)
         pagePaths.removeValue(forKey: key)
         textManager.deleteAllText(textBoxes: $textBoxes, key: uniqueKey(for: currentPage))
     }
-
+    
     private func goToNextPage() {
         if let pdfDoc = pdfDocument, currentPage < pdfDoc.pageCount - 1 {
             currentPage += 1
         }
     }
-
+    
     private func goToPreviousPage() {
         if currentPage > 0 {
             currentPage -= 1

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
@@ -50,7 +50,6 @@ struct PDFView: View {
                 ZStack {
                     if let pdfDoc = pdfDocument {
                         ZStack {
-                            // PDF Document View
                             DocumentView(
                                 pdfDocument: pdfDoc,
                                 currentPageIndex: $currentPage
@@ -62,7 +61,6 @@ struct PDFView: View {
                                 loadPaths(for: newValue)
                             }
 
-                            // Annotations
                             AnnotationsView(
                                 pagePaths: $pagePaths,
                                 highlightPaths: $highlightPaths,
@@ -82,7 +80,7 @@ struct PDFView: View {
                             .scaleEffect(zoomManager.newZoomLevel(),
                                          anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
 
-                            // Text Overlay
+                            // Annotations Text Overlay
                             TextView(
                                 textManager: textManager,
                                 textBoxes: $textBoxes,
@@ -164,20 +162,17 @@ struct PDFView: View {
                                 }
                             }
                             ToolbarItemGroup(placement: .bottomBar) {
-                                // Create a horizontal stack for the entire bottom toolbar
                                 HStack(spacing: 0) {
-                                    // Timer controls and progress bar should fill available space
                                     TimerProgressView(timerManager: timerManager)
                                         .frame(maxWidth: .infinity)
-
-                                    // Feedback button with minimal spacing
+                                    
                                     FeedbackView.button(
                                         feedbackManager: feedbackManager,
                                         workbook: currentWorkbook,
                                         currentPage: currentPage,
                                         collection: collection
                                     )
-                                    .padding(.leading, 4) // Minimal padding between progress bar and button
+                                    .padding(.leading, 4)
                                 }
                             }
                         }

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -110,23 +110,11 @@ struct SplitView: View {
             }
         }
         .onAppear {
-            fetchWorkbookAndChapters()
+            
 
             if let selectedWorkbookID {
                 currentPage = StateRestoreManager.shared.loadPageNumber(for: selectedWorkbookID)
             }
-
-            persistState()
-            /*
-            if let collection = initialCollection {
-                // Initialize currentCollection from initialCollection
-                currentCollection = collection
-            }
-            // Optionally, if initialPDFDocument is available, set it.
-            if let initialPDF = initialPDFDocument {
-                pdfDocument = initialPDF
-            }
-             */
         }
         .onChange(of: selectedWorkbookID) {
             fetchWorkbookAndChapters()
@@ -134,8 +122,6 @@ struct SplitView: View {
             if let selectedWorkbookID {
                 currentPage = StateRestoreManager.shared.loadPageNumber(for: selectedWorkbookID)
             }
-
-            persistState()
         }
         .onChange(of: currentPage) { _, _ in
             updateSelectedChapter()

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -34,7 +34,7 @@ struct SplitView: View {
     @State private var bookmarkManager = BookmarkManager()
 
     // PDFDocument loaded by PDFView
-    @State var pdfDocument: PDFDocument?
+    @State private var pdfDocument: PDFDocument?
 
     // Chapter manager, detemines chapter from current page
     @State private var chapterManager: ChapterManager?

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -14,7 +14,7 @@ struct SplitView: View {
     var initialCollection: Collection?
      */
     
-    var initialWorkbookID: Int?
+    //var initialWorkbookID: Int?
     
     // Loaded workbooks information state vars
     @Binding var workbooks: [WorkbookPreview]?
@@ -23,9 +23,9 @@ struct SplitView: View {
     @Binding var currentCollection: Collection?
 
     // User selection (what they are viewing) state vars
-    @State private var selectedWorkbookID: Int?
+    @State var selectedWorkbookID: Int?
     @State private var selectedChapterID: String?
-    @State private var currentWorkbook: Workbook?
+    @State var currentWorkbook: Workbook?
     @State private var currentPage: Int = 0
     @State private var columnVisibility = NavigationSplitViewVisibility.automatic
 
@@ -52,11 +52,13 @@ struct SplitView: View {
                     }
                 }
             } else {
+                /*
                 ProgressView("Fetching Workbooks")
                     .onAppear {
-                        selectedWorkbookID = initialWorkbookID
+                        
                         
                     }
+                 */
             }
         }
         content: {
@@ -108,6 +110,13 @@ struct SplitView: View {
             }
         }
         .onAppear {
+            fetchWorkbookAndChapters()
+
+            if let selectedWorkbookID {
+                currentPage = StateRestoreManager.shared.loadPageNumber(for: selectedWorkbookID)
+            }
+
+            persistState()
             /*
             if let collection = initialCollection {
                 // Initialize currentCollection from initialCollection

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -8,14 +8,6 @@ import PDFKit
 import SwiftUI
 
 struct SplitView: View {
-    /*
-    var initialWorkbooks: [WorkbookPreview] = []
-    var initialPDFDocument: PDFDocument?
-    var initialCollection: Collection?
-     */
-    
-    //var initialWorkbookID: Int?
-    
     // Loaded workbooks information state vars
     @State var workbooks: [WorkbookPreview]?
     @State var chapters: [Chapter]?
@@ -52,13 +44,7 @@ struct SplitView: View {
                     }
                 }
             } else {
-                /*
-                ProgressView("Fetching Workbooks")
-                    .onAppear {
-                        
-                        
-                    }
-                 */
+                 ProgressView("Fetching workbooks...")
             }
         }
         content: {
@@ -94,24 +80,18 @@ struct SplitView: View {
                 }
             }
         } detail: {
-            if currentWorkbook != nil {
-                // TODO: Only give access to bookmarks for current file.
-                PDFView(
-                    currentWorkbook: $currentWorkbook,
-                    currentPage: $currentPage,
-                    covers: $covers,
-                    pdfDocument: $pdfDocument,
-                    collection: $currentCollection,
-                    bookmarkManager: bookmarkManager
-                )
-                .blur(radius: networkingSingleton.isContentLoading ? 10 : 0)
-            } else {
-                ProgressView("Getting the latest workbook.")
-            }
+            // TODO: Only give access to bookmarks for current file.
+            PDFView(
+                currentWorkbook: $currentWorkbook,
+                currentPage: $currentPage,
+                covers: $covers,
+                pdfDocument: $pdfDocument,
+                collection: $currentCollection,
+                bookmarkManager: bookmarkManager
+            )
+            .blur(radius: networkingSingleton.isContentLoading ? 10 : 0)
         }
         .onAppear {
-            
-
             if let selectedWorkbookID {
                 currentPage = StateRestoreManager.shared.loadPageNumber(for: selectedWorkbookID)
             }
@@ -139,34 +119,6 @@ struct SplitView: View {
             StateRestoreManager.shared.saveState(workbookID: selectedWorkbookID, pageNumber: currentPage)
         }
     }
-
-    /*
-    func fetchWorkbooks() {
-        NetworkingService.shared.fetchWorkbooks(collection: currentCollection) { result in
-            switch result {
-            case let .success(workbookResponse):
-                workbooks = workbookResponse
-
-                // Try to load saved state now that workbooks are available.
-                if let savedState = StateRestoreManager.shared.loadState() {
-                    if workbookResponse.first(where: { $0.id == savedState.workbookID }) != nil {
-                        selectedWorkbookID = savedState.workbookID
-                        currentPage = savedState.pageNumber
-                    } else {
-                        // Fallback: default to the first workbook if the saved one isn't found.
-                        print("defaulting to first ")
-                        selectedWorkbookID = workbookResponse.first?.id
-                    }
-                } else {
-                    // No saved state, so select the first workbook by default.
-                    print("no saved state")
-                    selectedWorkbookID = workbookResponse.first?.id
-                }
-            case let .failure(error):
-                print("Error fetching workbooks: \(error)")
-            }
-        }
-    }*/
 
     func fetchWorkbookAndChapters() {
         guard let id = selectedWorkbook?.id else { return }

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -17,10 +17,10 @@ struct SplitView: View {
     //var initialWorkbookID: Int?
     
     // Loaded workbooks information state vars
-    @Binding var workbooks: [WorkbookPreview]?
+    @State var workbooks: [WorkbookPreview]?
     @State var chapters: [Chapter]?
     @State var covers: [Cover]?
-    @Binding var currentCollection: Collection?
+    @State var currentCollection: Collection?
 
     // User selection (what they are viewing) state vars
     @State var selectedWorkbookID: Int?
@@ -34,7 +34,7 @@ struct SplitView: View {
     @State private var bookmarkManager = BookmarkManager()
 
     // PDFDocument loaded by PDFView
-    @Binding var pdfDocument: PDFDocument?
+    @State var pdfDocument: PDFDocument?
 
     // Chapter manager, detemines chapter from current page
     @State private var chapterManager: ChapterManager?

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -8,16 +8,19 @@ import PDFKit
 import SwiftUI
 
 struct SplitView: View {
+    /*
     var initialWorkbooks: [WorkbookPreview] = []
-    var initialWorkbookID: Int?
     var initialPDFDocument: PDFDocument?
     var initialCollection: Collection?
-
+     */
+    
+    var initialWorkbookID: Int?
+    
     // Loaded workbooks information state vars
-    @State private var workbooks: [WorkbookPreview]?
-    @State private var chapters: [Chapter]?
-    @State private var covers: [Cover]?
-    @State private var currentCollection: Collection?
+    @Binding var workbooks: [WorkbookPreview]?
+    @State var chapters: [Chapter]?
+    @State var covers: [Cover]?
+    @Binding var currentCollection: Collection?
 
     // User selection (what they are viewing) state vars
     @State private var selectedWorkbookID: Int?
@@ -31,7 +34,7 @@ struct SplitView: View {
     @State private var bookmarkManager = BookmarkManager()
 
     // PDFDocument loaded by PDFView
-    @State private var pdfDocument: PDFDocument?
+    @Binding var pdfDocument: PDFDocument?
 
     // Chapter manager, detemines chapter from current page
     @State private var chapterManager: ChapterManager?
@@ -51,10 +54,8 @@ struct SplitView: View {
             } else {
                 ProgressView("Fetching Workbooks")
                     .onAppear {
-                        if !initialWorkbooks.isEmpty {
-                            workbooks = initialWorkbooks
-                            selectedWorkbookID = initialWorkbookID
-                        }
+                        selectedWorkbookID = initialWorkbookID
+                        
                     }
             }
         }
@@ -107,6 +108,7 @@ struct SplitView: View {
             }
         }
         .onAppear {
+            /*
             if let collection = initialCollection {
                 // Initialize currentCollection from initialCollection
                 currentCollection = collection
@@ -115,6 +117,7 @@ struct SplitView: View {
             if let initialPDF = initialPDFDocument {
                 pdfDocument = initialPDF
             }
+             */
         }
         .onChange(of: selectedWorkbookID) {
             fetchWorkbookAndChapters()
@@ -142,10 +145,9 @@ struct SplitView: View {
         }
     }
 
+    /*
     func fetchWorkbooks() {
-        guard let initialCollection else { return }
-
-        NetworkingService.shared.fetchWorkbooks(collection: initialCollection) { result in
+        NetworkingService.shared.fetchWorkbooks(collection: currentCollection) { result in
             switch result {
             case let .success(workbookResponse):
                 workbooks = workbookResponse
@@ -169,7 +171,7 @@ struct SplitView: View {
                 print("Error fetching workbooks: \(error)")
             }
         }
-    }
+    }*/
 
     func fetchWorkbookAndChapters() {
         guard let id = selectedWorkbook?.id else { return }
@@ -205,6 +207,8 @@ struct SplitView: View {
     }
 }
 
-#Preview {
-    SplitView()
-}
+/*
+ #Preview {
+ SplitView()
+ }
+ */

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift
@@ -44,7 +44,7 @@ struct SplitView: View {
                     }
                 }
             } else {
-                 ProgressView("Fetching workbooks...")
+                ProgressView("Fetching workbooks...")
             }
         }
         content: {


### PR DESCRIPTION
## Description

Adjusted the loading process for collection, workbook, and PDF document so that no redundant calls are being made to the API/NetworkingManager. Removed redundant variables and modified error messages to be more informative. Also removed several unnecessary methods

- **Motivation**:  As we move to production it is critical that there are not any calls being made to our backend that aren't absolutely necessary. Also helps with maintainability and readability

## Type of Change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [x] iOS  
  - [ ] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

`ReaderIOS/ReaderIOS/Controllers/InitializationManager.swift`
- Change 1:  Removed unnecessary PDF loading method, adjusted error messages, changed var type


`ReaderIOS/ReaderIOS/Views/SplitViewComponents/SplitView.swift`
- Change 2:  No longer stores initial values, just directly loads. No longer handles PDF loading


`ReaderIOS/ReaderIOS/ReaderIOSApp.swift`
- Change 3: Adjusted SplitView creation to work with Change 2


`ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift`
- Change 4: Fixed various UI elements (this required code formatting changes)


`ReaderIOS/ReaderIOS/Services/NetworkingService.swift`
- Change 5: Formatting fix

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

@devinhadley pointed out before that the initial vars were unnecessary, he was right lol.
