### PR TITLE
Kotlin PDF view rerender fix

### DIFF
--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -33,6 +33,12 @@ fun PDFViewer(
         navbarManager.setCollection(collectionViewModel)
     }
 
+    LaunchedEffect(workbook) {
+        // whenever workbook switches, force reload
+        pdfFile = null
+        lastLoadedFile = null
+    }
+
     // only fetch new file when workbook changes
     LaunchedEffect(workbook) {
         workbook?.let {

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -49,15 +49,10 @@ fun PDFViewer(modifier: Modifier = Modifier, navbarManager: NavbarManager, colle
                     }
                     .pageFling(true)
                     .pageSnap(true)
-                    .onPageChange { page, pageCount ->
-                        navbarManager.setPage(page)
-                        navbarManager.setPageCountValue(pageCount)
-                    }
                     .onLoad { navbarManager.setPage(pdfView.currentPage) }
                     .load()
                 pdfView.jumpTo(navbarManager.pageNumber)
             }
         }
     )
-    pdfFile = null
 }


### PR DESCRIPTION
## Description

Every time the page was changed it was reloading the entire PDF viewer due to the way the state was managed by Jetpack Compose. This caused weird graphical issues and is overall inefficient. Also, the PDFView now animates when the page is changed by navbarmanager

- **Motivation**:  The app should have a smooth experience and shouldn't waste resources reloading every time

## Type of Change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [ ] iOS  
  - [x] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

`ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt`
- Change 1:  Removed double calls to onPageChange
- Change 2: Only loads new page in viewer if it is not equivalent to current one
- Change 3: Monitors the current/previous file to check if it is different and only reloads if it has changed

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

First pointed out by @mollysandler, definitely needed to be fixed
