### PR TITLE
Page changes based on right/left side tap [iOS and Kotlin]

### DIFF
--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
@@ -2,7 +2,7 @@ import PDFKit
 import SwiftUI
 
 enum TapConstants {
-    static let nextPageTapRatio = 0.75
+    static let prevPageTapRatio = 0.25
 }
 
 struct AnnotationsView: View {
@@ -133,7 +133,7 @@ struct AnnotationsView: View {
                 // ——— PAGE TURNS ———
                 guard selectedScribbleTool.isEmpty else { return }
                 if !zoomManager.getZoomedIn() {
-                    if location.x > geometry.size.width * TapConstants.nextPageTapRatio {
+                    if location.x > geometry.size.width * TapConstants.prevPageTapRatio {
                         nextPage?()
                     } else {
                         previousPage?()

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
@@ -1,6 +1,10 @@
 import PDFKit
 import SwiftUI
 
+enum TapConstants {
+    static let nextPageTapRatio = 0.75
+}
+
 struct AnnotationsView: View {
     // MARK: - Bindings
 
@@ -130,12 +134,9 @@ struct AnnotationsView: View {
                 // Only do the tap‐to‐turn‐pages if you’re *not* in a drawing tool:
                 guard selectedScribbleTool.isEmpty else { return }
                 if(!zoomManager.getZoomedIn()){
-                    let w = geometry.size.width
-                    if location.x > w * 0.8 {
-                        // tapped on right 20%
+                    if location.x > geometry.size.width * TapConstants.nextPageTapRatio {
                         nextPage?()
                     } else {
-                        // tapped on left 80%
                         previousPage?()
                     }
                 }

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
@@ -113,6 +113,7 @@ struct AnnotationsView: View {
                 zoomManager.newZoomPoint(newPoint: location,
                                          width: geometry.size.width,
                                          height: geometry.size.height)
+                
                 if !textOpened, selectedScribbleTool == "Text" {
                     textOpened = true
                     textManager.addText(textBoxes: $textBoxes,
@@ -120,9 +121,25 @@ struct AnnotationsView: View {
                                         width: geometry.size.width,
                                         height: geometry.size.height)
                     textManager.saveTextBoxes(textBoxes: textBoxes)
-                } else {
-                    textOpened = false
+                    return
                 }
+                //else
+                textOpened = false
+                
+                // ——— PAGE TURNS ———
+                // Only do the tap‐to‐turn‐pages if you’re *not* in a drawing tool:
+                guard selectedScribbleTool.isEmpty else { return }
+                if(!zoomManager.getZoomedIn()){
+                    let w = geometry.size.width
+                    if location.x > w * 0.8 {
+                        // tapped on right 20%
+                        nextPage?()
+                    } else {
+                        // tapped on left 80%
+                        previousPage?()
+                    }
+                }
+                
             }
         }
         .onAppear {

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift
@@ -117,7 +117,7 @@ struct AnnotationsView: View {
                 zoomManager.newZoomPoint(newPoint: location,
                                          width: geometry.size.width,
                                          height: geometry.size.height)
-                
+
                 if !textOpened, selectedScribbleTool == "Text" {
                     textOpened = true
                     textManager.addText(textBoxes: $textBoxes,
@@ -127,20 +127,18 @@ struct AnnotationsView: View {
                     textManager.saveTextBoxes(textBoxes: textBoxes)
                     return
                 }
-                //else
+                // else
                 textOpened = false
-                
+
                 // ——— PAGE TURNS ———
-                // Only do the tap‐to‐turn‐pages if you’re *not* in a drawing tool:
                 guard selectedScribbleTool.isEmpty else { return }
-                if(!zoomManager.getZoomedIn()){
+                if !zoomManager.getZoomedIn() {
                     if location.x > geometry.size.width * TapConstants.nextPageTapRatio {
                         nextPage?()
                     } else {
                         previousPage?()
                     }
                 }
-                
             }
         }
         .onAppear {

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/util/AnnotationManager.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/util/AnnotationManager.kt
@@ -17,6 +17,12 @@ class AnnotationManager {
     var eraseEnabled by mutableStateOf(false)
         private set
 
+    val annotationsEnabled: Boolean
+        get() = scribbleEnabled
+            || penEnabled
+            || highlightEnabled
+            || eraseEnabled
+
     init {
         scribbleEnabled = false
         penEnabled = false

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/util/AnnotationManager.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/util/AnnotationManager.kt
@@ -18,10 +18,10 @@ class AnnotationManager {
         private set
 
     val annotationsEnabled: Boolean
-        get() = scribbleEnabled
-            || penEnabled
-            || highlightEnabled
-            || eraseEnabled
+        get() = scribbleEnabled ||
+            penEnabled ||
+            highlightEnabled ||
+            eraseEnabled
 
     init {
         scribbleEnabled = false

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -31,7 +31,7 @@ import com.kontinua.readersandroidjetpack.viewmodels.BookmarkViewModel
 import com.kontinua.readersandroidjetpack.viewmodels.CollectionViewModel
 import java.io.File
 
-private const val NEXT_PAGE_TAP_RATIO = 0.80f
+private const val NEXT_PAGE_TAP_RATIO = 0.75f
 
 @Composable
 fun PDFViewer(

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -111,7 +111,7 @@ fun PDFViewer(
                                 navbarManager.setPageCountValue(pageCount)
                             }
                             .onLoad { navbarManager.setPage(pdfView.currentPage) }
-                            .onPageScroll { page, offset ->
+                            .onPageScroll { _, _ ->
                                 currentZoom.floatValue = pdfView.zoom
                                 panOffset.value = Offset(
                                     -pdfView.currentXOffset,

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -31,7 +31,7 @@ import com.kontinua.readersandroidjetpack.viewmodels.BookmarkViewModel
 import com.kontinua.readersandroidjetpack.viewmodels.CollectionViewModel
 import java.io.File
 
-private const val NEXT_PAGE_TAP_RATIO = 0.75f
+private const val PREV_PAGE_TAP_RATIO = 0.25f
 
 @Composable
 fun PDFViewer(
@@ -123,7 +123,7 @@ fun PDFViewer(
                                 if (annotationManager.annotationsEnabled || pdfView.zoom != 1f) {
                                     false
                                 } else {
-                                    if (event.x > pdfView.width.toFloat() * NEXT_PAGE_TAP_RATIO) {
+                                    if (event.x > pdfView.width.toFloat() * PREV_PAGE_TAP_RATIO) {
                                         navbarManager.goToNextPage()
                                     } else {
                                         navbarManager.goToPreviousPage()

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -116,6 +116,30 @@ fun PDFViewer(
                                     -pdfView.currentYOffset
                                 )
                             }
+                            .onTap { event ->
+                                // if we’re zoomed or in annotation mode, don’t consume
+                                if (annotationManager.annotationsEnabled || pdfView.zoom != 1f) {
+                                    false
+                                } else {
+                                    val x = event.x
+                                    val w = pdfView.width.toFloat()
+                                    val cur = pdfView.currentPage
+                                    val cnt = pdfView.pageCount
+
+                                    if (x > w * 0.85f) {
+                                        // right 15% → next page
+                                        if (cur < cnt - 1) {
+                                            navbarManager.goToNextPage()
+                                        }
+                                    } else {
+                                        // left 85% → previous page
+                                        if (cur > 0) {
+                                            navbarManager.goToPreviousPage()
+                                        }
+                                    }
+                                    true
+                                }
+                            }
                             .load()
                     }
                     // only jump to the new page if it’s different

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -128,7 +128,7 @@ fun PDFViewer(
                                     } else {
                                         navbarManager.goToPreviousPage()
                                     }
-                                    //consume if page was changed
+                                    // consume if page was changed
                                     true
                                 }
                             }

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -31,7 +31,7 @@ import com.kontinua.readersandroidjetpack.viewmodels.BookmarkViewModel
 import com.kontinua.readersandroidjetpack.viewmodels.CollectionViewModel
 import java.io.File
 
-private const val NEXT_PAGE_TAP_RATIO = 0.85f
+private const val NEXT_PAGE_TAP_RATIO = 0.80f
 
 @Composable
 fun PDFViewer(
@@ -123,16 +123,12 @@ fun PDFViewer(
                                 if (annotationManager.annotationsEnabled || pdfView.zoom != 1f) {
                                     false
                                 } else {
-                                    val x = event.x
-                                    val w = pdfView.width.toFloat()
-
-                                    if (x > w * NEXT_PAGE_TAP_RATIO) {
-                                        // right 15% → next page
+                                    if (event.x > pdfView.width.toFloat() * NEXT_PAGE_TAP_RATIO) {
                                         navbarManager.goToNextPage()
                                     } else {
-                                        // left 85% → previous page
                                         navbarManager.goToPreviousPage()
                                     }
+                                    //consume if page was changed
                                     true
                                 }
                             }

--- a/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
+++ b/ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt
@@ -31,6 +31,8 @@ import com.kontinua.readersandroidjetpack.viewmodels.BookmarkViewModel
 import com.kontinua.readersandroidjetpack.viewmodels.CollectionViewModel
 import java.io.File
 
+private const val NEXT_PAGE_TAP_RATIO = 0.85f
+
 @Composable
 fun PDFViewer(
     modifier: Modifier = Modifier,
@@ -123,19 +125,13 @@ fun PDFViewer(
                                 } else {
                                     val x = event.x
                                     val w = pdfView.width.toFloat()
-                                    val cur = pdfView.currentPage
-                                    val cnt = pdfView.pageCount
 
-                                    if (x > w * 0.85f) {
+                                    if (x > w * NEXT_PAGE_TAP_RATIO) {
                                         // right 15% → next page
-                                        if (cur < cnt - 1) {
-                                            navbarManager.goToNextPage()
-                                        }
+                                        navbarManager.goToNextPage()
                                     } else {
                                         // left 85% → previous page
-                                        if (cur > 0) {
-                                            navbarManager.goToPreviousPage()
-                                        }
+                                        navbarManager.goToPreviousPage()
                                     }
                                     true
                                 }


### PR DESCRIPTION
## Description

The page can now be moved forward by tapping on the right 75% of the screen, or backward by tapping left 25%. Similar to Kindle or other eReader functionality. Disabled when zoomed in or annotating

- **Motivation**: Aaron request in last sprint review

## Type of Change

Please delete options that are not relevant.

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [ ] iOS  
  - [ ] Android  
  - [x] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

`ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/AnnotationsView.swift`
- Change 1: Added tap gesture recognizer to change page

`ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/views/PDFView.kt`
- Change 2:  Provides tap gesture recognizer to PDF viewer library's "onTap" property that changes page

`ReadersAndroidJetpack/app/src/main/java/com/kontinua/readersandroidjetpack/util/AnnotationManager.kt`
- Change 3: Added universal val to reflect whether any annotation features are enabled

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

Can change ratio based on Aaron preference, will discuss in sprint review
