### PR TITLE
remove s3 backend

### DIFF
--- a/backend/readers_backend/readers_backend/settings.py
+++ b/backend/readers_backend/readers_backend/settings.py
@@ -101,22 +101,13 @@ STORAGES = {
     },
 }
 
-# Static files storage directory in debug.
-if DEBUG:
-    MEDIA_URL = "/files/"
-    MEDIA_ROOT = os.path.join(BASE_DIR, "files")
+# Media files storage directory.
+# This is where pdfs will be stored.
+MEDIA_URL = "/files/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "files")
 
-# If we're in production we need to use S3 as our storage backend.
 if not DEBUG:
-    AWS_STORAGE_BUCKET_NAME = get_required_env_var("AWS_STORAGE_BUCKET_NAME")
-    AWS_S3_REGION_NAME = get_required_env_var("AWS_S3_REGION_NAME")
-    AWS_S3_ADDRESSING_STYLE = get_required_env_var("AWS_S3_ADDRESSING_STYLE")
-
-    STORAGES["default"] = {
-        "BACKEND": "storages.backends.s3.S3Storage",
-        "OPTIONS": {},
-    }
-
+    MEDIA_ROOT = get_required_env_var("MEDIA_ROOT")
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators

--- a/backend/readers_backend/requirements.txt
+++ b/backend/readers_backend/requirements.txt
@@ -3,7 +3,6 @@ attrs==25.1.0
 boto3==1.36.22
 botocore==1.36.22
 Django==5.1.6
-django-storages==1.14.5
 djangorestframework==3.15.2
 jmespath==1.0.1
 jsonschema==4.23.0


### PR DESCRIPTION
Migrates Django's default storage backend in prod from S3 to local file storage.

The reasoning is Nginx is highly capable at static file serve, and Aaron prefers keeping functionality out of AWS for now.