### PR TITLE
Fix populate db seed command to use en_US as localization

### DIFF
--- a/backend/readers_backend/core/management/commands/populate_db.py
+++ b/backend/readers_backend/core/management/commands/populate_db.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
             return
 
         collection = {
-            "localization": "en-US",
+            "localization": "en_US",
             "major_version": 1,
             "minor_version": 0,
         }


### PR DESCRIPTION
You guys will need to reset the postgres docker volume for the seed command to re run.

docker volume ls
(copy the name of the postgres volume)
docker volume rm (name of volume)