### PR TITLE
add throttling for feedback

### DIFF
--- a/backend/readers_backend/core/throttles.py
+++ b/backend/readers_backend/core/throttles.py
@@ -1,0 +1,5 @@
+from rest_framework.throttling import AnonRateThrottle
+
+
+class FeedbackThrottle(AnonRateThrottle):
+    scope = "feedback"

--- a/backend/readers_backend/core/views.py
+++ b/backend/readers_backend/core/views.py
@@ -5,6 +5,8 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from core.throttles import FeedbackThrottle
 from .utils import send_feedback_email
 from rest_framework.viewsets import GenericViewSet
 from django.utils import timezone
@@ -198,6 +200,7 @@ class FeedbackView(APIView):
 
     permission_classes = [AllowAny]  # Allow unauthenticated users to submit feedback
     serializer_class = FeedbackSerializer
+    throttle_classes = [FeedbackThrottle]
 
     def post(self, request):
         serializer = FeedbackSerializer(data=request.data)

--- a/backend/readers_backend/readers_backend/settings.py
+++ b/backend/readers_backend/readers_backend/settings.py
@@ -164,6 +164,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_THROTTLE_RATES": {
         "anon": "100/minute",
+        "feedback": "5/hour"
     },
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }


### PR DESCRIPTION
Because feedback sends emails, and we have limited number of daily emails, a rate limit on creating feedback is necessary.

I configured this limit to be 5 per hour for now.