### PR TITLE
Switch logging to use rotating file handler

### DIFF
--- a/backend/readers_backend/readers_backend/settings.py
+++ b/backend/readers_backend/readers_backend/settings.py
@@ -246,7 +246,7 @@ if SHOULD_LOG_TO_FILE:
                 "level": "INFO",
                 "class": "logging.handlers.RotatingFileHandler", 
                 "filename": RESPONSES_LOG_FILE,
-                "maxBytes": 5 * 1024 * 1024, # 5Mb
+                "maxBytes": 5 * 1024 * 1024, # 5MB
                 "backupCount": 5,
                 "formatter": "json",
             },


### PR DESCRIPTION
This will make it so each log file is 5MB with up to 5 backups.

So the max storage for logs is 3 (logs) * 6 (current log + 5 backups) * 5 (MB each) = 90 MB of space.