### PR TITLE
Annotation changes ios

### DIFF
--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/TextBoxView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/TextBoxView.swift
@@ -10,6 +10,7 @@ struct TextView: View {
     var height: CGFloat
     @Binding var textOpened: Bool
     @Binding var isHidden: Bool
+    let pageFrame: CGRect
 
     var body: some View {
         ZStack {
@@ -32,16 +33,9 @@ struct TextView: View {
                     }
                 }
             }
-            if textBoxes[key]?.count ?? 0 > 0 {
-                Image(systemName: isHidden ? "eye.slash" : "eye")
-                    .foregroundStyle(Color.blue)
-                    .font(.system(size: 25))
-                    .position(x: width - 111, y: height - 125)
-                    .onTapGesture(count: 1) {
-                        isHidden.toggle()
-                    }
-            }
         }
+        .frame(width: pageFrame.width, height: pageFrame.height)
+        .offset(x: pageFrame.origin.x, y: pageFrame.origin.y)
     }
 }
 
@@ -168,6 +162,7 @@ struct TextBox: View {
                     TapGesture()
                         .onEnded { _ in
                             deleteTextBox = true
+                            currentTextBoxIndex = index
                         }
                 )
                 .position(x: data.position.x + 100 * (data.size.width / 200),

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/TextBoxView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/AnnotationsComponents/TextBoxView.swift
@@ -154,6 +154,24 @@ struct TextBox: View {
                     x: data.position.x - 100 * (data.size.width / 200),
                     y: data.position.y - 50 * (data.size.height / 100)
                 )
+            Rectangle()
+                .frame(width: isFocused ? 20 : 0, height: isFocused ? 20 : 0)
+                .foregroundColor(Color.red)
+                .cornerRadius(3)
+                .position(x: data.position.x + 100 * (data.size.width / 200),
+                          y: data.position.y - 50 * (data.size.height / 100))
+            Image(systemName: "trash")
+                .frame(width: isFocused ? 20 : 0, height: isFocused ? 20 : 0)
+                .foregroundColor(Color.white)
+                .cornerRadius(3)
+                .gesture(
+                    TapGesture()
+                        .onEnded { _ in
+                            deleteTextBox = true
+                        }
+                )
+                .position(x: data.position.x + 100 * (data.size.width / 200),
+                          y: data.position.y - 50 * (data.size.height / 100))
         }
     }
 }

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/DocumentView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/DocumentView.swift
@@ -5,6 +5,7 @@ struct DocumentView: UIViewRepresentable {
     var pdfDocument: PDFDocument?
     // Binding directly connects the PDF components state with the parent, content view.
     @Binding var currentPageIndex: Int
+    @Binding var pageFrame: CGRect
 
     func makeUIView(context _: Context) -> PDFKit.PDFView {
         let pdfView = PDFKit.PDFView()
@@ -17,6 +18,15 @@ struct DocumentView: UIViewRepresentable {
 
         if uiView.document != pdfDocument {
             uiView.document = pdfDocument
+        }
+
+        if let page = pdfDocument.page(at: currentPageIndex) {
+            // Get the visible frame of the page in PDFView coordinates
+            let convertedFrame = uiView.convert(page.bounds(for: .cropBox), from: page)
+            DispatchQueue.main.async {
+                pageFrame = convertedFrame
+            }
+            uiView.go(to: page)
         }
 
         goToPage(in: uiView)

--- a/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
+++ b/ReaderIOS/ReaderIOS/Views/PDFViewComponents/PDFView.swift
@@ -41,7 +41,7 @@ struct PDFView: View {
     @State private var textOpened = false
     @State private var isHidden = false
     @State private var showClearAlert = false
-    @State private var isLandscape = false
+    @State private var pdfPageFrame: CGRect = .zero
 
     // MARK: - StateObjects and Observed
 
@@ -61,7 +61,8 @@ struct PDFView: View {
                         ZStack {
                             DocumentView(
                                 pdfDocument: pdfDoc,
-                                currentPageIndex: $currentPage
+                                currentPageIndex: $currentPage,
+                                pageFrame: $pdfPageFrame
                             )
                             .edgesIgnoringSafeArea(.all)
                             .scaleEffect(zoomManager.newZoomLevel(),
@@ -88,11 +89,12 @@ struct PDFView: View {
                                 zoomManager: zoomManager,
                                 annotationManager: annotationStorageManager,
                                 textManager: textManager,
-                                textBoxes: $textBoxes
+                                textBoxes: $textBoxes,
+                                isHidden: $isHidden,
+                                pageFrame: pdfPageFrame
                             )
                             .scaleEffect(zoomManager.newZoomLevel(),
                                          anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)
-
                             // Annotations Text Overlay
                             TextView(
                                 textManager: textManager,
@@ -103,7 +105,8 @@ struct PDFView: View {
                                 width: geometry.size.width,
                                 height: geometry.size.height,
                                 textOpened: $textOpened,
-                                isHidden: $isHidden
+                                isHidden: $isHidden,
+                                pageFrame: pdfPageFrame
                             )
                             .scaleEffect(zoomManager.newZoomLevel(),
                                          anchor: zoomManager.getZoomedIn() ? zoomManager.getZoomPoint() : .center)


### PR DESCRIPTION
## Description

Please include a summary of the changes. Also include relevant motivation and context. List any dependencies that are required for this change.

- **Motivation**: Helps to keep both android and ios versions as similar as possible, also allows the user to easily make annotations disappear and reappear when they feel like there is too much on the screen.

## Type of Change

Please delete options that are not relevant.

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [x] iOS  
  - [ ] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

- Change 1: You can now delete textboxes via the trash icon on the top right of the text box as per Aarons request.
- Change 2: All annotations can now be hidden when clicking the eye icon on bottom left. Also fixed the issue with different sized iPads having the eye button be misaligned.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

Eye button to hide annotations only appears when there are annotations on the screen. When in hidden mode you can change pages if markup tool is selected. If you go to a page with no annotations in hidden mode, when clicking the hide button, it disappears until annotations are added.