### PR TITLE
Persist Bookmarks after closing app on iOS

### DIFF
--- a/ReaderIOS/ReaderIOS/Controllers/BookmarkManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/BookmarkManager.swift
@@ -10,8 +10,8 @@ import Foundation
 
 final class BookmarkManager: ObservableObject {
     @Published var bookmarkLookup: [Int: Set<Int>]
-    
-    init(){
+
+    init() {
         bookmarkLookup = StateRestoreManager.shared.loadBookmarks()
     }
 
@@ -27,12 +27,12 @@ final class BookmarkManager: ObservableObject {
 
         var pages = bookmarkLookup[id] ?? []
         if pages.contains(currentPage) {
-          pages.remove(currentPage)
+            pages.remove(currentPage)
         } else {
-          pages.insert(currentPage)
+            pages.insert(currentPage)
         }
         bookmarkLookup[id] = pages
-        
+
         StateRestoreManager.shared.saveBookmarks(bookmarkLookup)
     }
 }

--- a/ReaderIOS/ReaderIOS/Controllers/BookmarkManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/BookmarkManager.swift
@@ -9,7 +9,11 @@ import Combine
 import Foundation
 
 final class BookmarkManager: ObservableObject {
-    @Published var bookmarkLookup: [Int: Set<Int>] = [:]
+    @Published var bookmarkLookup: [Int: Set<Int>]
+    
+    init(){
+        bookmarkLookup = StateRestoreManager.shared.loadBookmarks()
+    }
 
     /// Checks if the current page is bookmarked for the given file.
     func isBookmarked(workbook: Workbook?, currentPage: Int) -> Bool {
@@ -21,15 +25,14 @@ final class BookmarkManager: ObservableObject {
     func toggleBookmark(for workbook: Workbook?, currentPage: Int) {
         guard let id = workbook?.id else { return }
 
-        if var pages = bookmarkLookup[id] {
-            if pages.contains(currentPage) {
-                pages.remove(currentPage)
-            } else {
-                pages.insert(currentPage)
-            }
-            bookmarkLookup[id] = pages
+        var pages = bookmarkLookup[id] ?? []
+        if pages.contains(currentPage) {
+          pages.remove(currentPage)
         } else {
-            bookmarkLookup[id] = [currentPage]
+          pages.insert(currentPage)
         }
+        bookmarkLookup[id] = pages
+        
+        StateRestoreManager.shared.saveBookmarks(bookmarkLookup)
     }
 }

--- a/ReaderIOS/ReaderIOS/Controllers/StateRestoreManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/StateRestoreManager.swift
@@ -15,7 +15,7 @@ final class StateRestoreManager {
     // MARK: - UserDefaults Keys
 
     private let lastWorkbookKey = "lastWorkbook"
-    private let workbookPagesKey = "workbookPages" // Dictionary key
+    private let workbookPagesKey = "workbookPages"
     private let bookmarksKey = "bookmarkLookup"
 
     // Private initializer prevents external instantiation.
@@ -68,11 +68,11 @@ final class StateRestoreManager {
 
         return 0
     }
-    
+
     /// Persist the in-memory bookmark lookup.
     func saveBookmarks(_ lookup: [Int: Set<Int>]) {
         let defaults = UserDefaults.standard
-        
+
         // Convert [Int:Set<Int>] → [String:[Int]] so it's a plist-compatible value
         let plistFriendly: [String: [Int]] = Dictionary(
             uniqueKeysWithValues: lookup.map { workbookID, pages in
@@ -81,20 +81,20 @@ final class StateRestoreManager {
         )
         defaults.set(plistFriendly, forKey: bookmarksKey)
     }
-    
+
     func loadBookmarks() -> [Int: Set<Int>] {
         let defaults = UserDefaults.standard
-        
+
         guard let saved = defaults.dictionary(forKey: bookmarksKey) as? [String: [Int]] else {
-          return [:]
+            return [:]
         }
-        
+
         // Convert back to [Int: Set<Int>]
         return Dictionary(
-          uniqueKeysWithValues: saved.compactMap { key, array in
-            guard let id = Int(key) else { return nil }
-            return (id, Set(array))
-          }
+            uniqueKeysWithValues: saved.compactMap { key, array in
+                guard let id = Int(key) else { return nil }
+                return (id, Set(array))
+            }
         )
     }
 }

--- a/ReaderIOS/ReaderIOS/Controllers/StateRestoreManager.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/StateRestoreManager.swift
@@ -16,6 +16,7 @@ final class StateRestoreManager {
 
     private let lastWorkbookKey = "lastWorkbook"
     private let workbookPagesKey = "workbookPages" // Dictionary key
+    private let bookmarksKey = "bookmarkLookup"
 
     // Private initializer prevents external instantiation.
     private init() {}
@@ -66,5 +67,34 @@ final class StateRestoreManager {
         }
 
         return 0
+    }
+    
+    /// Persist the in-memory bookmark lookup.
+    func saveBookmarks(_ lookup: [Int: Set<Int>]) {
+        let defaults = UserDefaults.standard
+        
+        // Convert [Int:Set<Int>] → [String:[Int]] so it's a plist-compatible value
+        let plistFriendly: [String: [Int]] = Dictionary(
+            uniqueKeysWithValues: lookup.map { workbookID, pages in
+                (String(workbookID), Array(pages))
+            }
+        )
+        defaults.set(plistFriendly, forKey: bookmarksKey)
+    }
+    
+    func loadBookmarks() -> [Int: Set<Int>] {
+        let defaults = UserDefaults.standard
+        
+        guard let saved = defaults.dictionary(forKey: bookmarksKey) as? [String: [Int]] else {
+          return [:]
+        }
+        
+        // Convert back to [Int: Set<Int>]
+        return Dictionary(
+          uniqueKeysWithValues: saved.compactMap { key, array in
+            guard let id = Int(key) else { return nil }
+            return (id, Set(array))
+          }
+        )
     }
 }

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/BookmarkSearchView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/BookmarkSearchView.swift
@@ -14,7 +14,8 @@ struct BookmarkSearchView: View {
 
     var body: some View {
         if let currentWorkbook = currentWorkbook,
-           let bookmarks = bookmarkManager.bookmarkLookup[currentWorkbook.id]
+           let bookmarks = bookmarkManager.bookmarkLookup[currentWorkbook.id],
+           !bookmarks.isEmpty
         {
             List(Array(bookmarks).sorted(), id: \.self) { bookmark in
                 HStack {


### PR DESCRIPTION
## Description

Bookmarks created by user now persist after app is closed and reloaded.

- **Motivation**: It would not be very useful if bookmarks reset everytime the app is closed

## Type of Change

Please delete options that are not relevant.

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [x] iOS  
  - [ ] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

`ReaderIOS/ReaderIOS/Controllers/BookmarkManager.swift`
- Change 1: Send bookmark array to StateRestoreManager on every change

`ReaderIOS/ReaderIOS/Controllers/StateRestoreManager.swift`
- Change 2: Add bookmark list saving/loading functionality

`ReaderIOS/ReaderIOS/Views/SplitViewComponents/BookmarkSearchView.swift`
- Change 3: Show indicator that there a no bookmarks when list is empty

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

Could add names for each bookmark later
