### PR TITLE
iOS Search Fixes

### DIFF
--- a/ReaderIOS/ReaderIOS/Controllers/PDFSearchHighlighter.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/PDFSearchHighlighter.swift
@@ -14,11 +14,13 @@ class PDFSearchHighlighter: ObservableObject {
     init(pdfDoc: PDFDocument) {
         self.pdfDoc = pdfDoc
     }
+
     /// Highlight search result on a specific page
-    
+
     func highlightSearchResult(searchTerm: String,
                                onPage pageNumber: Int,
-                               color: UIColor = .yellow) {
+                               color: UIColor = .yellow)
+    {
         guard let page = pdfDoc.page(at: pageNumber),
               let text = page.string else { return }
 
@@ -31,8 +33,9 @@ class PDFSearchHighlighter: ObservableObject {
         // Build a pattern that matches any whitespace (including newline)
         let pattern = terms.joined(separator: "\\s+")
         guard let regex = try? NSRegularExpression(
-                pattern: pattern,
-                options: [.caseInsensitive]) else { return }
+            pattern: pattern,
+            options: [.caseInsensitive]
+        ) else { return }
 
         let nsText = text as NSString
         let fullRange = NSRange(location: 0, length: nsText.length)
@@ -46,7 +49,8 @@ class PDFSearchHighlighter: ObservableObject {
                     let highlight = PDFAnnotation(
                         bounds: lineSel.bounds(for: page),
                         forType: .highlight,
-                        withProperties: nil)
+                        withProperties: nil
+                    )
                     highlight.color = color.withAlphaComponent(0.7)
                     page.addAnnotation(highlight)
                     currentHighlights.append(highlight)

--- a/ReaderIOS/ReaderIOS/Controllers/PDFSearchHighlighter.swift
+++ b/ReaderIOS/ReaderIOS/Controllers/PDFSearchHighlighter.swift
@@ -14,64 +14,51 @@ class PDFSearchHighlighter: ObservableObject {
     init(pdfDoc: PDFDocument) {
         self.pdfDoc = pdfDoc
     }
-
     /// Highlight search result on a specific page
-    func highlightSearchResult(searchTerm: String, onPage pageNumber: Int, color: UIColor = .yellow) {
-        guard let page = pdfDoc.page(at: pageNumber) else { return }
+    
+    func highlightSearchResult(searchTerm: String,
+                               onPage pageNumber: Int,
+                               color: UIColor = .yellow) {
+        guard let page = pdfDoc.page(at: pageNumber),
+              let text = page.string else { return }
 
-        // Get the full page text
-        guard let pageContent = page.string?.lowercased() else { return }
-
-        // Get search terms
-        let searchTerms = searchTerm.lowercased()
+        // Split into terms, escape regex metacharacters
+        let terms = searchTerm
             .components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
+            .map { NSRegularExpression.escapedPattern(for: $0) }
 
-        // Find the location of the search terms in the page content
-        if let range = findSearchTermRange(searchTerms: searchTerms, in: pageContent) {
-            // Convert string range to PDF selection
-            if let selection = page.selection(for: range) {
-                // Create highlight annotation
-                let highlight = PDFAnnotation(bounds: selection.bounds(for: page),
-                                              forType: .highlight,
-                                              withProperties: nil)
+        // Build a pattern that matches any whitespace (including newline)
+        let pattern = terms.joined(separator: "\\s+")
+        guard let regex = try? NSRegularExpression(
+                pattern: pattern,
+                options: [.caseInsensitive]) else { return }
 
-                highlight.color = color.withAlphaComponent(0.7)
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
 
-                page.addAnnotation(highlight)
-
-                // Store reference to highlight for later removal
-                currentHighlights.append(highlight)
+        // Find all matches
+        let matches = regex.matches(in: text, options: [], range: fullRange)
+        for match in matches {
+            if let selection = page.selection(for: match.range) {
+                // Break into per-line pieces so highlights don't bleed across lines
+                for lineSel in selection.selectionsByLine() {
+                    let highlight = PDFAnnotation(
+                        bounds: lineSel.bounds(for: page),
+                        forType: .highlight,
+                        withProperties: nil)
+                    highlight.color = color.withAlphaComponent(0.7)
+                    page.addAnnotation(highlight)
+                    currentHighlights.append(highlight)
+                }
             }
         }
     }
 
-    /// Remove all current highlights
     func clearHighlights() {
-        for highlight in currentHighlights {
-            if let page = highlight.page {
-                page.removeAnnotation(highlight)
-            }
+        for cur in currentHighlights {
+            cur.page?.removeAnnotation(cur)
         }
         currentHighlights.removeAll()
-    }
-
-    /// Find the range of the search terms in the page content
-    private func findSearchTermRange(searchTerms: [String], in pageContent: String) -> NSRange? {
-        // For single term search
-        if searchTerms.count == 1 {
-            let searchTerm = searchTerms[0]
-            return (pageContent as NSString).range(
-                of: searchTerm,
-                options: .caseInsensitive
-            )
-        }
-
-        // For multi-term search
-        let searchPhrase = searchTerms.joined(separator: " ")
-        return (pageContent as NSString).range(
-            of: searchPhrase,
-            options: .caseInsensitive
-        )
     }
 }

--- a/ReaderIOS/ReaderIOS/Models/PDFWordsIndex.swift
+++ b/ReaderIOS/ReaderIOS/Models/PDFWordsIndex.swift
@@ -4,6 +4,7 @@ enum PDFBoundsConstants {
     static let headerPct = 0.90 // pct of page (from bottom) at which headers are located
     static let footerPct = 0.10
 }
+
 class PDFWordsIndex: ObservableObject {
     // Dictionary mapping words to the pages they appear on
     @Published private var wordToPages: [String: Set<Int>] = [:]
@@ -23,7 +24,7 @@ class PDFWordsIndex: ObservableObject {
         pageTokens.removeAll()
         tokenRanges.removeAll()
 
-        for pageIndex in 0..<pdf.pageCount {
+        for pageIndex in 0 ..< pdf.pageCount {
             guard let page = pdf.page(at: pageIndex),
                   let pageContent = page.attributedString else { continue }
 
@@ -44,7 +45,7 @@ class PDFWordsIndex: ObservableObject {
                 if let token = scanner.scanCharacters(from: .alphanumerics) {
                     let endIndex = scanner.currentIndex
                     let startIndex = plainText.index(endIndex, offsetBy: -token.count)
-                    let strRange = startIndex..<endIndex
+                    let strRange = startIndex ..< endIndex
 
                     // Convert to NSRange so PDFKit can map it
                     let nsRange = NSRange(strRange, in: plainText)
@@ -53,7 +54,7 @@ class PDFWordsIndex: ObservableObject {
                         let midY = bounds.midY
 
                         // Skip tokens in header/footer regions
-                        guard midY < headerCutoff && midY > footerCutoff else {
+                        guard midY < headerCutoff, midY > footerCutoff else {
                             continue
                         }
 

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
@@ -95,7 +95,7 @@ struct SearchView: View {
                                             print("Highlighting \(result.snippet) on page \(result.page + 1)")
                                             searchHighlighter?.clearHighlights()
                                             searchHighlighter?.highlightSearchResult(
-                                                searchTerm: result.snippet,
+                                                searchTerm: searchText,
                                                 onPage: result.page
                                             )
                                             columnVisibility = .detailOnly

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
@@ -92,10 +92,10 @@ struct SearchView: View {
                                         }
                                         .onTapGesture {
                                             currentPage = result.page
-                                            print("Highlighting \(result.snippet) on page \(result.page + 1)")
+                                            print("Highlighting '\(result.snippet)' on page \(result.page + 1)")
                                             searchHighlighter?.clearHighlights()
                                             searchHighlighter?.highlightSearchResult(
-                                                searchTerm: searchText,
+                                                searchTerm: result.snippet,
                                                 onPage: result.page
                                             )
                                             columnVisibility = .detailOnly

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
@@ -112,9 +112,6 @@ struct SearchView: View {
                     .onAppear(perform: fetchWorkbookAndChapters)
             }
         }
-        .onAppear {
-            indexPDFDocument()
-        }
         .onChange(of: pdfDocument) { _, _ in
             indexPDFDocument()
         }

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
@@ -92,7 +92,7 @@ struct SearchView: View {
                                         }
                                         .onTapGesture {
                                             currentPage = result.page
-                                            
+
                                             Logger.info("Highlighting '\(result.snippet)' on page \(result.page + 1)")
                                             searchHighlighter?.clearHighlights()
                                             searchHighlighter?.highlightSearchResult(

--- a/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
+++ b/ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift
@@ -92,7 +92,8 @@ struct SearchView: View {
                                         }
                                         .onTapGesture {
                                             currentPage = result.page
-                                            print("Highlighting '\(result.snippet)' on page \(result.page + 1)")
+                                            
+                                            Logger.info("Highlighting '\(result.snippet)' on page \(result.page + 1)")
                                             searchHighlighter?.clearHighlights()
                                             searchHighlighter?.highlightSearchResult(
                                                 searchTerm: result.snippet,


### PR DESCRIPTION
## Description

Results no longer include the header of each page, highlighting works much more consistently, other bug fixes

- **Motivation**:  Search should work very well, also Aaron requested improved highlighting

## Type of Change

Please delete options that are not relevant.

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Refactor** (improving existing code without changing its behavior)
- [ ] **Documentation Update**

## Mobile Specific Considerations

- **Platform(s)**:  
  - [x] iOS  
  - [ ] Android  
  - [ ] Both  
- **Device/OS Versions Tested**: _(e.g., iOS 15 on iPhone 12, Android 12 on Pixel 5)_

## Changes Made

Describe your changes. Include file paths

`ReaderIOS/ReaderIOS/Controllers/PDFSearchHighlighter.swift`
- Change 1: Changed the way text is detected to include newlines for more accurate highlighting

`ReaderIOS/ReaderIOS/Models/PDFWordsIndex.swift`
- Change 2: Uses bounds of page to eliminate terms in header area from search index

`ReaderIOS/ReaderIOS/Views/SplitViewComponents/SearchView.swift`
- Change 3: Added logger and removed unnecessary indexing call

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions if necessary

- [ ] Tested on **real devices** (please specify models and OS versions):
- [x] Tested on **simulators/emulators**.

## Additional Context

Add any other context about the pull request here.
